### PR TITLE
Update walking skeleton doc to include OpenCodelists

### DIFF
--- a/docs/walking_skeleton.md
+++ b/docs/walking_skeleton.md
@@ -9,6 +9,9 @@ flowchart TD
     inspect_locally --> update_locally
     inspect_locally --> push_to_gh[Push to GitHub]
     end
+    subgraph OpenCodelists
+    create_codelist[Create/update codelist] --> create_branch
+    end
     subgraph GitHub
     push_to_gh --> run_ci[Code is run in CI]
     run_ci -->|CI failure| update_locally


### PR DESCRIPTION
This updates the walking skeleton doc to include an OpenCodelists sub-graph. The sub-graph is intentionally minimal, and can be expanded in time. Thanks for noticing that OpenCodelists was missing, @richiecroker!