### PR TITLE
Don't set `PYTHONPATH`

### DIFF
--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -1,6 +1,5 @@
+import measures
 import streamlit
-
-from app import measures
 
 
 def main():

--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ devenv: requirements-dev prodenv (_install 'dev') && install-pre-commit
 
 # Run a Streamlit app
 run *args: devenv
-    PYTHONPATH=. {{ STREAMLIT }} run {{ args }}
+    {{ STREAMLIT }} run {{ args }}
 
 # Run tests
 test *args: devenv


### PR DESCRIPTION
Unfortunately, Streamlit Community Cloud doesn't allow us to set `PYTHONPATH`. Consequently, our imports must be relative to the directory within which the "main file" is located, which in this case is `app/sro_key_measures.py`, rather than relative to the project root directory.