### PR TITLE
Translate ALT key measure to ehrQL

### DIFF
--- a/analysis/measure_definition.py
+++ b/analysis/measure_definition.py
@@ -1,0 +1,71 @@
+import argparse
+from datetime import date
+
+from ehrql import INTERVAL, Measures, codelist_from_csv, months
+from ehrql.tables.core import clinical_events as events
+from ehrql.tables.core import patients
+from ehrql.tables.tpp import practice_registrations as registrations
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--codelist")
+args = parser.parse_args()
+
+start_date = date(2024, 4, 1)
+
+
+def num_months(from_, to_):
+    """Returns the number of months between the given dates."""
+    return abs(to_.year - from_.year) * 12 + abs(from_.month - to_.month)
+
+
+# same year, same month
+assert num_months(date(2025, 1, 1), date(2025, 1, 31)) == 0
+# different year, different month
+assert num_months(date(2024, 1, 1), date(2025, 2, 1)) == 13
+# to_ before from_
+assert num_months(date(2025, 2, 1), date(2024, 1, 1)) == 13
+
+
+# Demographic variables
+# --------------------------------------------------------------------------------------
+is_alive = patients.is_alive_on(INTERVAL.start_date)
+
+age = patients.age_on(INTERVAL.start_date)
+is_adult = (age >= 18) & (age < 120)
+
+registration = registrations.for_patient_on(INTERVAL.start_date)
+is_registered = registration.exists_for_patient()
+
+is_sex_recorded = patients.sex.is_in(["male", "female"])
+
+
+# Codelists
+# --------------------------------------------------------------------------------------
+codelist = codelist_from_csv(args.codelist, column="code")
+codelist_events = events.where(
+    events.snomedct_code.is_in(codelist) & events.date.is_during(INTERVAL)
+)
+has_codelist_event = codelist_events.exists_for_patient()
+last_codelist_event = codelist_events.sort_by(codelist_events.date).last_for_patient()
+
+
+# Measures
+# --------------------------------------------------------------------------------------
+measures = Measures()
+measures.define_defaults(
+    denominator=is_alive & is_adult & is_registered & is_sex_recorded
+)
+intervals = months(num_months(start_date, date.today())).starting_on(start_date)
+measures.define_measure(
+    name="by_practice",
+    numerator=has_codelist_event,
+    intervals=intervals,
+    group_by={"practice": registration.practice_pseudo_id},
+)
+measures.define_measure(
+    name="by_snomedct_code",
+    numerator=has_codelist_event,
+    intervals=intervals,
+    group_by={"snomedct_code": last_codelist_event.snomedct_code},
+)

--- a/codelists/codelists.json
+++ b/codelists/codelists.json
@@ -1,3 +1,10 @@
 {
-  "files": {}
+  "files": {
+    "opensafely-alanine-aminotransferase-alt-tests.csv": {
+      "id": "opensafely/alanine-aminotransferase-alt-tests/2298df3e",
+      "url": "https://www.opencodelists.org/codelist/opensafely/alanine-aminotransferase-alt-tests/2298df3e/",
+      "downloaded_at": "2025-01-02 16:40:55.314645Z",
+      "sha": "0d231653e5ece343f6945309d21fc40c7f685ff2"
+    }
+  }
 }

--- a/codelists/codelists.txt
+++ b/codelists/codelists.txt
@@ -1,0 +1,1 @@
+opensafely/alanine-aminotransferase-alt-tests/2298df3e

--- a/codelists/opensafely-alanine-aminotransferase-alt-tests.csv
+++ b/codelists/opensafely-alanine-aminotransferase-alt-tests.csv
@@ -1,0 +1,14 @@
+code,term
+1013211000000103,Plasma alanine aminotransferase level
+1018251000000107,Serum alanine aminotransferase level
+104481004,"Alanine aminotransferase measurement, method with pyridoxal-5'-phosphate"
+104482006,"Alanine aminotransferase measurement, method without pyridoxal-5'-phosphate"
+201321000000108,Serum alanine aminotransferase level
+219651000000107,Serum alanine aminotransferase level
+219661000000105,Serum alanine aminotransferase level
+250637003,Alanine aminotransferase - blood measurement
+34608000,Alanine aminotransferase measurement
+389586005,Plasma alanine aminotransferase level
+390318006,Plasma alanine aminotransferase level
+390961000,Plasma alanine aminotransferase level
+889391000000100,Measurement of alanine transaminase activity

--- a/project.yaml
+++ b/project.yaml
@@ -1,8 +1,13 @@
 version: "4.0"
 
 actions:
-  generate_dataset:
-    run: ehrql:v1 generate-dataset analysis/dataset_definition.py --output output/dataset.csv.gz
+  generate_measures_alt_tests:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/alt_tests/measures.arrow
+        --
+        --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
     outputs:
       highly_sensitive:
-        dataset: output/dataset.csv.gz
+        measures: output/alt_tests/measures.arrow


### PR DESCRIPTION
The measure definition is parametrized by a codelist, such that it can be applied to any number of codelists. The measures file is written to a sub-directory of the `outputs` directory, because we anticipate a downstream transformation action reading the measures file and writing a transformed file, suitable for releasing and publishing.