### PR TITLE
Add single practice scenario

### DIFF
--- a/app/measures.py
+++ b/app/measures.py
@@ -25,6 +25,11 @@ class Measure:
     total_events: int
     top_5_codes_table: pandas.DataFrame
     deciles_table: pandas.DataFrame
+    scenario_table: pandas.DataFrame = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        idx = pandas.Index(self.quarters, name="date")
+        self.scenario_table = pandas.Series(0, idx, name="value").to_frame()
 
     def __repr__(self):
         return f"Measure(name='{self.name}')"
@@ -46,6 +51,29 @@ class Measure:
         pct_change = (to_val - from_val) / from_val
 
         return from_val, to_val, pct_change
+
+    @property
+    def range(self):
+        return self.deciles_table["value"].min(), self.deciles_table["value"].max()
+
+    @property
+    def quarters(self):
+        date = self.deciles_table["date"]
+        return [
+            d.to_pydatetime().date()
+            for d in pandas.date_range(date.min(), date.max(), freq="QS")
+        ]
+
+    def update_scenario_table(self, quarter, value):
+        self.scenario_table.loc[quarter, "value"] = value
+
+    @property
+    def scenario_chart(self):
+        return (
+            altair.Chart(self.scenario_table.reset_index())
+            .mark_line(color="red")
+            .encode(x="date", y="value")
+        )
 
     @property
     def deciles_chart(self):

--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -1,4 +1,5 @@
 import measures
+import numpy
 import streamlit
 
 
@@ -27,7 +28,20 @@ def main():
     with streamlit.expander("Caveats"):
         streamlit.markdown(measure.caveats)
 
-    streamlit.altair_chart(measure.deciles_chart, use_container_width=True)
+    with streamlit.expander("Single practice scenario"):
+        min_value, max_value = measure.range
+        for quarter in measure.quarters:
+            value = streamlit.slider(
+                quarter.isoformat(),
+                min_value,
+                max_value,
+                value=numpy.random.uniform(min_value, max_value),
+            )
+            measure.update_scenario_table(quarter, value)
+
+    streamlit.altair_chart(
+        measure.deciles_chart + measure.scenario_chart, use_container_width=True
+    )
 
     streamlit.markdown(f"**Most common codes ([codelist]({measure.codelist_url}))**")
 


### PR DESCRIPTION
This adds a red line, which represents a "single practice scenario", to the deciles chart. More specifically, it places the scenario chart above the deciles chart, to give a [layered chart][1].

The values for the scenario chart are provided by the user, although initial values are chosen at random and are within the range of the measures table. To keep the number of values, and hence the number of sliders, to a reasonable number, only values for the quarters covered by the measures table are provided.

Live dashboard: <https://open-pathology-single-practice-scenario.streamlit.app/>

---

Notice that the live dashboard doesn't _quite_ work as described 🙁 If you move a slider, then the scenario chart is created anew, with new initial values. For more information, see "[Understanding widget behavior][2]".

[1]: https://altair-viz.github.io/user_guide/compound_charts.html#layered-charts
[2]: https://docs.streamlit.io/develop/concepts/architecture/widget-behavior