### PR TITLE
Log and cache `OSJobsRepository`

### DIFF
--- a/app/measures.py
+++ b/app/measures.py
@@ -3,8 +3,11 @@ import pathlib
 
 import altair
 import pandas
+import structlog
 import yaml
 
+
+log = structlog.get_logger(__name__)
 
 PERCENTILE = "Percentile"
 DECILE = "Decile"
@@ -95,6 +98,7 @@ class OSJobsRepository:
 
     def get(self, name):
         """Get the measure with the given name from the repository."""
+        log.info(f'Getting "{name}" from the repository')
         if name not in self._measures:
             self._measures[name] = self._construct(name)
         return self._measures[name]
@@ -102,6 +106,7 @@ class OSJobsRepository:
     def _construct(self, name):
         """Construct the measure with the given name from information stored on the
         local file system and on OS Jobs."""
+        log.info(f'Constructing "{name}"')
         record = self._records[name]
 
         # The following helpers don't need access to instance attributes, so we define
@@ -128,10 +133,12 @@ class OSJobsRepository:
 
 
 def _get_counts(counts_table_url):
+    log.info(f"Getting counts table from {counts_table_url}")
     return pandas.read_csv(counts_table_url, index_col=0).to_dict().get("count")
 
 
 def _get_top_5_codes_table(top_5_codes_table_url):
+    log.info(f"Getting top 5 codes table from {top_5_codes_table_url}")
     top_5_codes_table = pandas.read_csv(
         top_5_codes_table_url, index_col=0, dtype={"Code": str}
     )
@@ -142,6 +149,7 @@ def _get_top_5_codes_table(top_5_codes_table_url):
 
 
 def _get_deciles_table(deciles_table_url):
+    log.info(f"Getting deciles table from {deciles_table_url}")
     deciles_table = pandas.read_csv(deciles_table_url, parse_dates=["date"])
     deciles_table.loc[:, "label"] = PERCENTILE
     deciles_table.loc[deciles_table["percentile"] % 10 == 0, "label"] = DECILE

--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -2,8 +2,13 @@ import measures
 import streamlit
 
 
+@streamlit.cache_resource
+def get_repository():
+    return measures.OSJobsRepository()
+
+
 def main():
-    repository = measures.OSJobsRepository()
+    repository = get_repository()
 
     selected_measure_name = streamlit.selectbox("Select a measure:", repository.list())
 

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -1,2 +1,3 @@
 pyyaml
 streamlit
+structlog

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -87,6 +87,8 @@ smmap==5.0.1
     # via gitdb
 streamlit==1.41.0
     # via -r requirements.prod.in
+structlog==24.4.0
+    # via -r requirements.prod.in
 tenacity==9.0.0
     # via streamlit
 toml==0.10.2


### PR DESCRIPTION
For convenience, we add [`structlog`](https://www.structlog.org/en/stable/) as a requirement and then use it to log calls within `app/measures.py` that cross system boundaries. We then cache the repository, making it globally available.

It's worth checking out d627c23, switching between measures in the dashboard, and observing the logs. Then checkout 8153638 (`HEAD`), and observe the logs again.

I wouldn't say any of ☝🏻 is strictly necessary, but it helped me understand more about [Streamlit's execution model](https://docs.streamlit.io/develop/concepts/architecture). It might help you too 🙂 