### PR TITLE
Exploratory changes to how the single practice scenario is configured

### DIFF
--- a/app/measures.py
+++ b/app/measures.py
@@ -28,7 +28,7 @@ class Measure:
     scenario_table: pandas.DataFrame = dataclasses.field(init=False)
 
     def __post_init__(self):
-        idx = pandas.Index(self.quarters, name="date")
+        idx = pandas.Index(self.months, name="date")
         self.scenario_table = pandas.Series(0.0, idx, name="value").to_frame()
 
     def __repr__(self):
@@ -57,15 +57,15 @@ class Measure:
         return self.deciles_table["value"].min(), self.deciles_table["value"].max()
 
     @property
-    def quarters(self):
+    def months(self):
         date = self.deciles_table["date"]
         return [
             d.to_pydatetime().date()
-            for d in pandas.date_range(date.min(), date.max(), freq="QS")
+            for d in pandas.date_range(date.min(), date.max(), freq="MS")
         ]
 
-    def update_scenario_table(self, quarter, value):
-        self.scenario_table.loc[quarter, "value"] = value
+    def update_scenario_table(self, month, value):
+        self.scenario_table.loc[month, "value"] = value
 
     @property
     def scenario_chart(self):

--- a/app/measures.py
+++ b/app/measures.py
@@ -25,11 +25,6 @@ class Measure:
     total_events: int
     top_5_codes_table: pandas.DataFrame
     deciles_table: pandas.DataFrame
-    scenario_table: pandas.DataFrame = dataclasses.field(init=False)
-
-    def __post_init__(self):
-        idx = pandas.Index(self.months, name="date")
-        self.scenario_table = pandas.Series(0.0, idx, name="value").to_frame()
 
     def __repr__(self):
         return f"Measure(name='{self.name}')"
@@ -63,17 +58,6 @@ class Measure:
             d.to_pydatetime().date()
             for d in pandas.date_range(date.min(), date.max(), freq="MS")
         ]
-
-    def update_scenario_table(self, month, value):
-        self.scenario_table.loc[month, "value"] = value
-
-    @property
-    def scenario_chart(self):
-        return (
-            altair.Chart(self.scenario_table.reset_index())
-            .mark_line(color="red")
-            .encode(x="date", y="value")
-        )
 
     @property
     def deciles_chart(self):

--- a/app/single_practice_scenario.py
+++ b/app/single_practice_scenario.py
@@ -3,10 +3,14 @@ import numpy
 import pandas
 
 
+DATE_COL = "Date"
+VALUE_COL = "Rate per 1,000 registered patients"
+
+
 def get_randomised_scenario_table(intervals, min_value, max_value):
-    idx = pandas.Index(intervals, name="date")
-    df = pandas.Series(0.0, idx, name="value").to_frame()
-    df.loc[:, "value"] = numpy.random.uniform(min_value, max_value, len(df)).round(2)
+    idx = pandas.Index(intervals, name=DATE_COL)
+    df = pandas.Series(0.0, idx, name=VALUE_COL).to_frame()
+    df.loc[:, VALUE_COL] = numpy.random.uniform(min_value, max_value, len(df)).round(2)
     return df
 
 
@@ -19,5 +23,5 @@ class ScenarioAccessor:
         return (
             altair.Chart(self._obj.reset_index())
             .mark_line(color="red")
-            .encode(x="date", y="value")
+            .encode(x=DATE_COL, y=VALUE_COL)
         )

--- a/app/single_practice_scenario.py
+++ b/app/single_practice_scenario.py
@@ -1,0 +1,21 @@
+import altair
+import pandas
+
+
+def get_blank_scenario_table(intervals):
+    idx = pandas.Index(intervals, name="date")
+    df = pandas.Series(0.0, idx, name="value").to_frame()
+    return df
+
+
+@pandas.api.extensions.register_dataframe_accessor("scenario")
+class ScenarioAccessor:
+    def __init__(self, pandas_obj):
+        self._obj = pandas_obj
+
+    def to_chart(self):
+        return (
+            altair.Chart(self._obj.reset_index())
+            .mark_line(color="red")
+            .encode(x="date", y="value")
+        )

--- a/app/single_practice_scenario.py
+++ b/app/single_practice_scenario.py
@@ -1,10 +1,12 @@
 import altair
+import numpy
 import pandas
 
 
-def get_blank_scenario_table(intervals):
+def get_randomised_scenario_table(intervals, min_value, max_value):
     idx = pandas.Index(intervals, name="date")
     df = pandas.Series(0.0, idx, name="value").to_frame()
+    df.loc[:, "value"] = numpy.random.uniform(min_value, max_value, len(df)).round(2)
     return df
 
 

--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -58,13 +58,13 @@ def main():
         editable_table = streamlit.data_editor(
             streamlit.session_state[scenario_table_key].loc[months],
             use_container_width=True,
-            disabled=("date",),
-            column_config={"value": {"alignment": "left"}},
+            disabled=(single_practice_scenario.DATE_COL,),
+            column_config={single_practice_scenario.VALUE_COL: {"alignment": "left"}},
         )
         # Store the user-provided values back in the session state
-        streamlit.session_state[scenario_table_key].loc[months, "value"] = (
-            editable_table.loc[months, "value"]
-        )
+        streamlit.session_state[scenario_table_key].loc[months] = editable_table.loc[
+            months
+        ]
 
     streamlit.altair_chart(
         measure.deciles_chart + editable_table.scenario.to_chart(),

--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -1,5 +1,6 @@
 import measures
 import numpy
+import single_practice_scenario
 import streamlit
 
 
@@ -48,6 +49,7 @@ def main():
         frequency = streamlit.number_input("Frequency (months)", 1, 12, 3)
         months = measure.months[idx_start : idx_end + 1 : frequency]
 
+        scenario_table = single_practice_scenario.get_blank_scenario_table(months)
         for month in months:
             key = f"{measure.name}_{month.isoformat()}"
             save_value_if_missing(key, numpy.random.uniform(min_value, max_value))
@@ -57,11 +59,11 @@ def main():
                 max_value,
                 key=key,
             )
-            measure.update_scenario_table(month, streamlit.session_state[key])
-        measure.scenario_table = measure.scenario_table.loc[months]
+            scenario_table.loc[month, "value"] = streamlit.session_state[key]
 
     streamlit.altair_chart(
-        measure.deciles_chart + measure.scenario_chart, use_container_width=True
+        measure.deciles_chart + scenario_table.scenario.to_chart(),
+        use_container_width=True,
     )
 
     streamlit.markdown(f"**Most common codes ([codelist]({measure.codelist_url}))**")

--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -35,16 +35,30 @@ def main():
 
     with streamlit.expander("Single practice scenario"):
         min_value, max_value = measure.range
-        for quarter in measure.quarters:
-            key = f"{measure.name}_{quarter.isoformat()}"
+        idx_start = measure.months.index(
+            streamlit.selectbox("Start", options=measure.months[:-1])
+        )
+        idx_end = measure.months.index(
+            streamlit.selectbox(
+                "End",
+                options=measure.months[idx_start + 1 :],
+                index=len(measure.months) - idx_start - 2,
+            )
+        )
+        frequency = streamlit.number_input("Frequency (months)", 1, 12, 3)
+        months = measure.months[idx_start : idx_end + 1 : frequency]
+
+        for month in months:
+            key = f"{measure.name}_{month.isoformat()}"
             save_value_if_missing(key, numpy.random.uniform(min_value, max_value))
             streamlit.slider(
-                quarter.isoformat(),
+                month.isoformat(),
                 min_value,
                 max_value,
                 key=key,
             )
-            measure.update_scenario_table(quarter, streamlit.session_state[key])
+            measure.update_scenario_table(month, streamlit.session_state[key])
+        measure.scenario_table = measure.scenario_table.loc[months]
 
     streamlit.altair_chart(
         measure.deciles_chart + measure.scenario_chart, use_container_width=True


### PR DESCRIPTION
This PR will be ready to merge only after discussion on which commits are worth keeping.  Merging this pull request will result in changes being reflected at https://open-pathology-single-practice-scenario.streamlit.app/.

f3469ac27622f14df9ec5e6dc231e1dc58e4acfe
The changes proposed provide additional flexibility for a user to configure the number of (and date range) of the red single practice scenario line. See the commit message.

42e11c90cba24da415f2353c8aded09086d8b5b2
- Also see the commit message
- The changes proposed are to ensure that user input of single practice scenario data is consistent with repository being a cached resource in the main branch (This was implemented in #27 and brought into the base branch via rebasing in #32).
- [A cached resource in streamlit is a singleton across user sessions](https://docs.streamlit.io/develop/concepts/architecture/caching#stcache_resource). Presumably, we would not want user-provided data to be shared globally, so it is preferable to store the scenario table values in the session state only.
- This commit detaches the scenario table from the `Measure` class to achieve that. IMO the exact code changes warrant a review before merging.

76da9698bf4071cc28033c4d752af3cb89ca3148
This commit experiments with replacing the sliders with an editable table. See the commit message.
It may need editing if f3469ac27622f14df9ec5e6dc231e1dc58e4acfe is dropped from the PR.

Commits cf4f664962bd44fcc08c5a2d0b3a6124222855e1 and 30d62ab434b8d3a96811ad01e136496629b1506e are optional cosmetic improvements to the changes in 76da9698bf4071cc28033c4d752af3cb89ca3148.




