### PR TITLE
Update measures definition to include counts for comparators and ref ranges

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -73,5 +73,5 @@ actions:
       --
       --codelist codelists/opensafely-alanine-aminotransferase-alt-tests.csv
     outputs:
-      moderately_sensitive:
+      highly_sensitive:
         dataset: output/sdr/test.csv

--- a/sdr/dataset.py
+++ b/sdr/dataset.py
@@ -6,7 +6,7 @@ import argparse
 from ehrql import INTERVAL, Measures, codelist_from_csv, months, years
 from ehrql.tables.core import clinical_events as events
 from ehrql.tables.core import patients
-from ehrql.tables.tpp import practice_registrations as registrations
+from ehrql.tables.tpp import practice_registrations as registrations, clinical_events_ranges as ranges
 from ehrql import create_dataset
 
 dataset = create_dataset()
@@ -18,15 +18,42 @@ end_date = "2021-03-31"
 
 # Codelists
 # --------------------------------------------------------------------------------------
+
+# Codelists
 codelist = codelist_from_csv(args.codelist, column="code")
-codelist_events = events.where(
-    events.snomedct_code.is_in(codelist) & events.date.is_on_or_between(start_date, end_date)
+codelist_events = ranges.where(
+    ranges.snomedct_code.is_in(codelist) & ranges.date.is_on_or_between(start_date, end_date)
 )
 
-dataset.region = registrations.for_patient_on(start_date).practice_nuts1_region_name
+# Stratification variables
+region = registrations.for_patient_on(start_date).practice_nuts1_region_name
 
-dataset.codelist_event_count = codelist_events.count_for_patient()
+# Presence of codelist (denominator)
+codelist_event_count = codelist_events.count_for_patient()
 
-dataset.test_value_count = codelist_events.where(events.numeric_value.is_not_null()).count_for_patient()
+# Booleans
+has_test_value = ranges.numeric_value.is_not_null()
+has_equality_comparator = ranges.comparator.is_in(['=','~'])
+has_differential_comparator = (ranges.comparator.is_not_null() & ~has_equality_comparator)
+has_upper_bound = ranges.upper_bound.is_not_null()
+has_lower_bound = ranges.lower_bound.is_not_null()
+
+# Generate all combinations of test_value, equality_comparator, differential_comparator, upper_bound, and lower_bound
+# E.g. valT_equalT_diffF_uppT_lowF
+count_measures = dict()
+for value in [True, False]:
+    # Use zip to exclude equal_compT, diff_compT (since both can't be true)
+    for equal_comp, diff_comp in zip([True, False, False], [False, True, False]):
+            for upper in [True, False]:
+                for lower in [True, False]:
+                    key = f"val{'T' if value else 'F'}_equal{'T' if equal_comp else 'F'}_diff{'T' if diff_comp else 'F'}_upp{'T' if upper else 'F'}_low{'T' if lower else 'F'}"
+                    count_measures[key] = codelist_events.where(
+                        (has_test_value if value else ~has_test_value) &
+                        (has_equality_comparator if equal_comp else ~has_equality_comparator) &
+                        (has_differential_comparator if diff_comp else ~has_differential_comparator) &
+                        (has_upper_bound if upper else ~has_upper_bound) &
+                        (has_lower_bound if lower else ~has_lower_bound)
+                    ).count_for_patient()
+                    dataset.add_column(key, count_measures[key])
 
 dataset.define_population(patients.exists_for_patient())

--- a/sdr/measures-definition.py
+++ b/sdr/measures-definition.py
@@ -1,9 +1,9 @@
-from datetime import date
 import argparse
-from ehrql import INTERVAL, Measures, codelist_from_csv, months, years
-from ehrql.tables.core import clinical_events as events
-from ehrql.tables.core import patients
+
+from ehrql import INTERVAL, Measures, codelist_from_csv, years
+from ehrql.tables.tpp import clinical_events_ranges as ranges
 from ehrql.tables.tpp import practice_registrations as registrations
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--codelist")
@@ -12,8 +12,8 @@ index_date = "2018-01-01"
 
 # Codelists
 codelist = codelist_from_csv(args.codelist, column="code")
-codelist_events = events.where(
-    events.snomedct_code.is_in(codelist) & events.date.is_during(INTERVAL)
+codelist_events = ranges.where(
+    ranges.snomedct_code.is_in(codelist) & ranges.date.is_during(INTERVAL)
 )
 
 # Stratification variables
@@ -22,22 +22,83 @@ region = registrations.for_patient_on(INTERVAL.start_date).practice_nuts1_region
 # Presence of codelist (denominator)
 codelist_event_count = codelist_events.count_for_patient()
 
-# Non-null test value count
-test_value_count = codelist_events.where(events.numeric_value.is_not_null()).count_for_patient()
+# Booleans
+has_test_value = ranges.numeric_value.is_not_null()
+has_comparator = ranges.comparator.is_not_null()
+has_upper_bound = ranges.upper_bound.is_not_null()
+has_lower_bound = ranges.lower_bound.is_not_null()
 
+has_2_bound = has_upper_bound & has_lower_bound
+has_1_bound = (has_upper_bound | has_lower_bound) & ~has_2_bound
+has_0_bound = ~has_upper_bound & ~has_lower_bound
+
+count_measures = dict()
+# Venn diagram
+
+# Value and comparator
+count_measures["valueT_comparator_T_bounds2"] = ranges.where(
+    has_test_value & has_comparator & has_2_bound
+).count_for_patient()
+
+count_measures["valueT_comparatorT_bounds1"] = ranges.where(
+    has_test_value & has_comparator & has_1_bound
+).count_for_patient()
+
+count_measures["valueT_comparatorT_bounds0"] = ranges.where(
+    has_test_value & has_comparator & has_0_bound
+).count_for_patient()
+
+# Value and no comparator
+count_measures["valueT_comparatorF_bounds2"] = ranges.where(
+    has_test_value & ~has_comparator & has_2_bound
+).count_for_patient()
+
+count_measures["valueT_comparatorF_bounds1"] = ranges.where(
+    has_test_value & ~has_comparator & has_1_bound
+).count_for_patient()
+
+count_measures["valueT_comparatorF_bounds0"] = ranges.where(
+    has_test_value & ~has_comparator & has_0_bound
+).count_for_patient()
+
+# No value and comparator
+count_measures["valueF_comparatorT_bounds2"] = ranges.where(
+    ~has_test_value & has_comparator & has_2_bound
+).count_for_patient()
+
+count_measures["valueF_comparatorT_bounds1"] = ranges.where(
+    ~has_test_value & has_comparator & has_1_bound
+).count_for_patient()
+
+count_measures["valueF_comparatorT_bounds0"] = ranges.where(
+    ~has_test_value & has_comparator & has_0_bound
+).count_for_patient()
+
+# No value and no comparator
+count_measures["valueF_comparatorF_bounds2"] = ranges.where(
+    ~has_test_value & ~has_comparator & has_2_bound
+).count_for_patient()
+
+count_measures["valueF_comparatorF_bounds1"] = ranges.where(
+    ~has_test_value & ~has_comparator & has_1_bound
+).count_for_patient()
+
+count_measures["valueF_comparatorF_bounds0"] = ranges.where(
+    ~has_test_value & ~has_comparator & has_0_bound
+).count_for_patient()
 
 # Measures
 # --------------------------------------------------------------------------------------
 measures = Measures()
 measures.configure_dummy_data(population_size=1000, legacy=True)
 measures.define_defaults(
-    denominator= codelist_event_count
-)
-
-intervals = years(7).starting_on(index_date)
-measures.define_measure(
-    name="test_value_present",
-    numerator=test_value_count,
-    intervals=intervals,
+    denominator=codelist_event_count,
+    intervals=years(7).starting_on(index_date),
     group_by={"region": region},
 )
+
+for m, numerator in count_measures.items():
+    measures.define_measure(
+        name=m,
+        numerator=numerator,
+    )

--- a/sdr/test_dataset.py
+++ b/sdr/test_dataset.py
@@ -3,13 +3,14 @@ from dataset import dataset
 
 test_data = {
     1: { 
-        "clinical_events": [{'numeric_value': 7, "snomedct_code": "1013211000000103", "date": date(2020, 4, 1)}, {"snomedct_code": "1013211000000103", "date": date(2020, 4, 1)}],
-        "patients": {},
+        "clinical_events_ranges": [{'numeric_value': 30, "snomedct_code": "1013211000000103", "date": date(2020, 4, 1), "lower_bound": 23, "upper_bound": 76, "comparator": '<'}, 
+                                  {'numeric_value': 30, "snomedct_code": "1013211000000103", "date": date(2020, 4, 1), "lower_bound": 23, "upper_bound": 76, "comparator": '~'}],
+        "patients": {"sex": 'male'},
         "practice_registrations": {},
         "expected_in_population": True,
         "expected_columns": {
-            "codelist_event_count": 2,
-            "test_value_count": 1
+            "valT_equalF_diffT_uppT_lowT": 1,
+            "valT_equalT_diffF_uppT_lowT": 1,
         },
     }
 }


### PR DESCRIPTION
Related to #35 
- Count the smallest components of the venn diagram. Counts for values, values+comparators, values+refrange can be calculated by summation
- Therefore, only measure from the `clinical_events_ranges` table