### PR TITLE
Remove total patient count from dashboard

### DIFF
--- a/app/measures.py
+++ b/app/measures.py
@@ -21,7 +21,6 @@ class Measure:
     caveats: str
     classification: str
     codelist_url: str
-    unique_patients: int
     total_events: int
     top_5_codes_table: pandas.DataFrame
     deciles_table: pandas.DataFrame
@@ -121,7 +120,6 @@ class OSJobsRepository:
             record["caveats"],
             record["classification"],
             record["codelist_url"],
-            counts["unique_patients"],
             counts["total_events"],
             top_5_codes_table,
             deciles_table,

--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -33,11 +33,7 @@ def main():
 
     streamlit.dataframe(measure.top_5_codes_table)
 
-    streamlit.markdown(
-        "Total patients: "
-        f"**{measure.unique_patients:,}** "
-        f"({measure.total_events:,} events)"
-    )
+    streamlit.markdown(f"Total events: {measure.total_events:,} events")
 
     for from_year, to_year in [(2019, 2020), (2019, 2021)]:
         from_val, to_val, pct_change = measure.change_in_median(from_year, to_year, 4)


### PR DESCRIPTION
The current ehrQL code for the measures does not query for the total count of patients.
Hence, that data will not be available to us.
Do not show it on the dashboard, and remove it from the `Measure` dataclass.