### PR TITLE
Fix reference ranges

### DIFF
--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -17,6 +17,5 @@ jobs:
       uses: opensafely-core/research-action@v2
       with:
         actions: generate_processed_data_alt_mtx_ref_tests generate_processed_data_alt_mtx_tests generate_processed_data_alt_tests
-          generate_processed_data_chol_tests generate_processed_data_hba1c_diab_mean_tests generate_processed_data_hba1c_diab_tests
-          generate_processed_data_psa_ref_tests generate_processed_data_psa_tests generate_processed_data_systol_tests
-          generate_processed_data_vit_d_ref_tests generate_processed_data_vit_d_tests
+          generate_processed_data_hba1c_diab_mean_tests generate_processed_data_psa_ref_tests generate_processed_data_systol_tests
+          generate_processed_data_vit_d_ref_tests 

--- a/analysis/measure_definition.py
+++ b/analysis/measure_definition.py
@@ -187,27 +187,36 @@ elif 'mtx' in args.test:
 elif 'hba1c_diab' in args.test:
     denominator = denominator & is_diabetic
 
-# Remove tests with unreliable numeric values & reference ranges for measures that depend on that field
-if ('mean' in args.test) | ('ref' in args.test):
-    has_codelist_event = (events_table.where(
-                            (events_table.numeric_value.is_not_null()) & 
-                            (events_table.numeric_value > 0) &
+# Remove tests with unreliable numeric values 
+# For mean, sum(numeric_value) / sum(patients who had a test) = mean value of tests (ratio column)
+if 'mean' in args.test:
+    
+    numerator = numeric_value
 
-                            (events_table.upper_bound.is_not_null()) & 
-                            (events_table.upper_bound > 0) &
-                            
-                            (events_table.lower_bound.is_not_null()) & 
-                            (events_table.lower_bound > 0) 
-                            )
-                            .exists_for_patient())
+    has_codelist_event = (codelist_events.where(
+                    (codelist_events.numeric_value.is_not_null()) & 
+                    (codelist_events.numeric_value > 0))
+                    .exists_for_patient())
+
     denominator = denominator & has_codelist_event
+# Remove tests with unreliable numeric values & reference ranges for measures that depend on that field
+elif 'ref' in args.test:
 
-    # For mean, sum(numeric_value) / sum(patients who had a test) = mean value of tests (ratio column)
-    if 'mean' in args.test:
-        numerator = numeric_value
+    numerator = tests_outside_ref
 
-    elif'ref' in args.test:
-        numerator = tests_outside_ref
+    has_codelist_event = (events_table.where(
+                    (events_table.numeric_value.is_not_null()) & 
+                    (events_table.numeric_value > 0) &
+
+                    (events_table.upper_bound.is_not_null()) & 
+                    (events_table.upper_bound > 0) &
+                    
+                    (events_table.lower_bound.is_not_null()) & 
+                    (events_table.lower_bound > 0) 
+                    )
+                    .exists_for_patient())
+
+    denominator = denominator & has_codelist_event
 
 measures.define_defaults(
     numerator = numerator,

--- a/analysis/measure_definition.py
+++ b/analysis/measure_definition.py
@@ -101,8 +101,9 @@ if 'alt' in args.test:
     # Use numeric alt codelist for reference range measure
     if 'ref' in args.test:
         codelist_path = codelists['alt_numeric']
+    else: 
+        codelist_path = codelists['alt']
 
-    codelist_path = codelists['alt']
 # hb1c_numeric codelist is needed to remove misleading % value from mean calculation
 elif 'hba1c' in args.test:
     codelist_path = codelists['hba1c_numeric']
@@ -186,11 +187,18 @@ elif 'mtx' in args.test:
 elif 'hba1c_diab' in args.test:
     denominator = denominator & is_diabetic
 
-# Remove tests with unreliable numeric values for measures that depend on that field
+# Remove tests with unreliable numeric values & reference ranges for measures that depend on that field
 if ('mean' in args.test) | ('ref' in args.test):
-    has_codelist_event = (codelist_events.where(
-                            (codelist_events.numeric_value.is_not_null()) & 
-                            (codelist_events.numeric_value > 0))
+    has_codelist_event = (events_table.where(
+                            (events_table.numeric_value.is_not_null()) & 
+                            (events_table.numeric_value > 0) &
+
+                            (events_table.upper_bound.is_not_null()) & 
+                            (events_table.upper_bound > 0) &
+                            
+                            (events_table.lower_bound.is_not_null()) & 
+                            (events_table.lower_bound > 0) 
+                            )
                             .exists_for_patient())
     denominator = denominator & has_codelist_event
 

--- a/analysis/test_dataset.py
+++ b/analysis/test_dataset.py
@@ -109,6 +109,7 @@ test_data_options = {
                 "date": date(2018, 4, 15),
                 "snomedct_code": "1013211000000103",
                 "numeric_value": 5,
+                "lower_bound": 3,
                 "upper_bound": 7,
             }
         ],
@@ -131,6 +132,7 @@ test_data_options = {
                 "date": date(2017, 10, 15),
                 "snomedct_code": "1013211000000103",
                 "numeric_value": 5,
+                "lower_bound": 2,
                 "upper_bound": 7,
             }
         ],
@@ -142,7 +144,32 @@ test_data_options = {
             "tests_outside_ref": False,
         },
     },
-    7: {  # hba1c_diab_mean numeric_value within 1 months
+    7: {  # alt-mtx-ref within 1 months, null bound
+        "patients": {"date_of_birth": date(1950, 1, 1), "sex": "male"},
+        "medications": [
+            {"date": date(2018, 2, 15), "dmd_code": "12816911000001103"},
+            {"date": date(2017, 11, 15), "dmd_code": "12816911000001103"},
+        ],
+        "clinical_events": [
+            {"date": date(2018, 4, 15), "snomedct_code": "1013211000000103"}
+        ],
+        "clinical_events_ranges": [
+            {
+                "date": date(2018, 4, 15),
+                "snomedct_code": "1013211000000103",
+                "numeric_value": 5,
+                "lower_bound": 1,
+            }
+        ],
+        "practice_registrations": [
+            {"start_date": date(2010, 1, 1), "end_date": date(2025, 1, 1)}
+        ],
+        "expected_in_population": False,
+        "expected_columns": {
+            "tests_outside_ref": False,
+        },
+    },
+    8: {  # hba1c_diab_mean numeric_value within 1 months
         "patients": {"date_of_birth": date(1950, 1, 1), "sex": "male"},
         "medications": [],
         "clinical_events": [
@@ -162,7 +189,7 @@ test_data_options = {
             "mean": 4,
         },
     },
-    8: {  # hba1c_diab numeric_value outside 6 months
+    9: {  # hba1c_diab numeric_value outside 6 months
         "patients": {"date_of_birth": date(1950, 1, 1), "sex": "male"},
         "medications": [],
         "clinical_events": [
@@ -184,7 +211,7 @@ test_data_options = {
             "has_codelist_event": False,
         },
     },
-    9: {  # Negative control
+    10: {  # Negative control
         "patients": {"date_of_birth": date(1950, 1, 1), "sex": "male"},
         "medications": [],
         "clinical_events": [],
@@ -202,14 +229,14 @@ if args.test == "vit_d_ref":
 elif args.test == "psa_ref":
     patients = [3, 4]
 elif args.test == "alt_mtx_ref":
-    patients = [5, 6]
+    patients = [5, 6, 7]
 elif args.test == "hba1c_diab_mean":
-    patients = [7]
-elif args.test == "hba1c_diab":
     patients = [8]
+elif args.test == "hba1c_diab":
+    patients = [9]
 
 # Add the negative control patient
-patients.append(9)
+patients.append(10)
 test_data = {}
 for patient in patients:
     test_data[patient] = test_data_options[patient]

--- a/generate_yaml.py
+++ b/generate_yaml.py
@@ -44,7 +44,7 @@ yaml_template = """
       [generate_measures_{test}_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/{test}_tests/*per_week_per_practice.csv
+        monthly_tables: output/{test}_tests/*table_counts_per_week*.csv
         code_table: output/{test}_tests/top_5_code_table.csv
         event_counts_table: output/{test}_tests/event_counts.csv
   generate_processed_data_{test}_tests_sim:
@@ -85,6 +85,16 @@ for test in tests.keys():
 
     yaml_body += yaml_template.format(test = test)
 
-yaml = yaml_header + yaml_body
+yaml_plots = """
+  generate_plots:
+    run: >
+      r:latest 
+        analysis/plots.r
+    outputs:
+      moderately_sensitive:
+        plots: output*.png
+"""
+
+yaml = yaml_header + yaml_body + yaml_plots
 with open("project.yaml", "w") as file:
        file.write(yaml)

--- a/project.yaml
+++ b/project.yaml
@@ -23,7 +23,7 @@ actions:
       [generate_measures_alt_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/alt_tests/*per_week_per_practice.csv
+        monthly_tables: output/alt_tests/*table_counts_per_week*.csv
         code_table: output/alt_tests/top_5_code_table.csv
         event_counts_table: output/alt_tests/event_counts.csv
   generate_processed_data_alt_tests_sim:
@@ -72,7 +72,7 @@ actions:
       [generate_measures_chol_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/chol_tests/*per_week_per_practice.csv
+        monthly_tables: output/chol_tests/*table_counts_per_week*.csv
         code_table: output/chol_tests/top_5_code_table.csv
         event_counts_table: output/chol_tests/event_counts.csv
   generate_processed_data_chol_tests_sim:
@@ -121,7 +121,7 @@ actions:
       [generate_measures_hba1c_numeric_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/hba1c_numeric_tests/*per_week_per_practice.csv
+        monthly_tables: output/hba1c_numeric_tests/*table_counts_per_week*.csv
         code_table: output/hba1c_numeric_tests/top_5_code_table.csv
         event_counts_table: output/hba1c_numeric_tests/event_counts.csv
   generate_processed_data_hba1c_numeric_tests_sim:
@@ -170,7 +170,7 @@ actions:
       [generate_measures_rbc_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/rbc_tests/*per_week_per_practice.csv
+        monthly_tables: output/rbc_tests/*table_counts_per_week*.csv
         code_table: output/rbc_tests/top_5_code_table.csv
         event_counts_table: output/rbc_tests/event_counts.csv
   generate_processed_data_rbc_tests_sim:
@@ -219,7 +219,7 @@ actions:
       [generate_measures_sodium_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/sodium_tests/*per_week_per_practice.csv
+        monthly_tables: output/sodium_tests/*table_counts_per_week*.csv
         code_table: output/sodium_tests/top_5_code_table.csv
         event_counts_table: output/sodium_tests/event_counts.csv
   generate_processed_data_sodium_tests_sim:
@@ -268,7 +268,7 @@ actions:
       [generate_measures_systol_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/systol_tests/*per_week_per_practice.csv
+        monthly_tables: output/systol_tests/*table_counts_per_week*.csv
         code_table: output/systol_tests/top_5_code_table.csv
         event_counts_table: output/systol_tests/event_counts.csv
   generate_processed_data_systol_tests_sim:
@@ -317,7 +317,7 @@ actions:
       [generate_measures_vit_d_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/vit_d_tests/*per_week_per_practice.csv
+        monthly_tables: output/vit_d_tests/*table_counts_per_week*.csv
         code_table: output/vit_d_tests/top_5_code_table.csv
         event_counts_table: output/vit_d_tests/event_counts.csv
   generate_processed_data_vit_d_tests_sim:
@@ -366,7 +366,7 @@ actions:
       [generate_measures_vit_d_ref_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/vit_d_ref_tests/*per_week_per_practice.csv
+        monthly_tables: output/vit_d_ref_tests/*table_counts_per_week*.csv
         code_table: output/vit_d_ref_tests/top_5_code_table.csv
         event_counts_table: output/vit_d_ref_tests/event_counts.csv
   generate_processed_data_vit_d_ref_tests_sim:
@@ -415,7 +415,7 @@ actions:
       [generate_measures_psa_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/psa_tests/*per_week_per_practice.csv
+        monthly_tables: output/psa_tests/*table_counts_per_week*.csv
         code_table: output/psa_tests/top_5_code_table.csv
         event_counts_table: output/psa_tests/event_counts.csv
   generate_processed_data_psa_tests_sim:
@@ -464,7 +464,7 @@ actions:
       [generate_measures_psa_ref_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/psa_ref_tests/*per_week_per_practice.csv
+        monthly_tables: output/psa_ref_tests/*table_counts_per_week*.csv
         code_table: output/psa_ref_tests/top_5_code_table.csv
         event_counts_table: output/psa_ref_tests/event_counts.csv
   generate_processed_data_psa_ref_tests_sim:
@@ -513,7 +513,7 @@ actions:
       [generate_measures_hba1c_diab_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/hba1c_diab_tests/*per_week_per_practice.csv
+        monthly_tables: output/hba1c_diab_tests/*table_counts_per_week*.csv
         code_table: output/hba1c_diab_tests/top_5_code_table.csv
         event_counts_table: output/hba1c_diab_tests/event_counts.csv
   generate_processed_data_hba1c_diab_tests_sim:
@@ -562,7 +562,7 @@ actions:
       [generate_measures_hba1c_diab_mean_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/hba1c_diab_mean_tests/*per_week_per_practice.csv
+        monthly_tables: output/hba1c_diab_mean_tests/*table_counts_per_week*.csv
         code_table: output/hba1c_diab_mean_tests/top_5_code_table.csv
         event_counts_table: output/hba1c_diab_mean_tests/event_counts.csv
   generate_processed_data_hba1c_diab_mean_tests_sim:
@@ -611,7 +611,7 @@ actions:
       [generate_measures_alt_mtx_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/alt_mtx_tests/*per_week_per_practice.csv
+        monthly_tables: output/alt_mtx_tests/*table_counts_per_week*.csv
         code_table: output/alt_mtx_tests/top_5_code_table.csv
         event_counts_table: output/alt_mtx_tests/event_counts.csv
   generate_processed_data_alt_mtx_tests_sim:
@@ -660,7 +660,7 @@ actions:
       [generate_measures_alt_mtx_ref_tests]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/alt_mtx_ref_tests/*per_week_per_practice.csv
+        monthly_tables: output/alt_mtx_ref_tests/*table_counts_per_week*.csv
         code_table: output/alt_mtx_ref_tests/top_5_code_table.csv
         event_counts_table: output/alt_mtx_ref_tests/event_counts.csv
   generate_processed_data_alt_mtx_ref_tests_sim:
@@ -688,3 +688,11 @@ actions:
     outputs:
       highly_sensitive:
         population: output/tests/alt_mtx_ref_dataset.csv
+
+  generate_plots:
+    run: >
+      r:latest 
+        analysis/plots.r
+    outputs:
+      moderately_sensitive:
+        plots: output*.png


### PR DESCRIPTION
### Change notes
- Change alt_mtx_ref logic to use numeric value codelist
- Change ref measures logic to only include non-null reference ranges
- Generate decile plot for quick check of charts
- Fix demograph processing

- (Potentially) remove proxy nulls from ref ranges depending on iain/alex meet

### Actions to run
- Following test pipelines should be re-run: vit_d_ref, alt_mtx_ref, psa_ref
- Following test processing actions should be re-run to get demographic tables: 'alt', 'chol', 'hba1c', 'hba1c_numeric', 'rbc', 'sodium', 'systol'
- Following new action should be run: generate_plots
