### PR TITLE
Troubleshoot reference ranges

### DIFF
--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -18,4 +18,4 @@ jobs:
       with:
         actions: generate_processed_data_alt_mtx_ref_tests generate_processed_data_alt_mtx_tests generate_processed_data_alt_tests
           generate_processed_data_hba1c_diab_mean_tests generate_processed_data_psa_ref_tests generate_processed_data_systol_tests
-          generate_processed_data_vit_d_ref_tests 
+          generate_processed_data_vit_d_ref_tests generate_processed_data_alt_mtx_ref_tests_light

--- a/analysis/measure_definition.py
+++ b/analysis/measure_definition.py
@@ -10,6 +10,7 @@ from config import codelists
 # Parse input test choice
 parser = argparse.ArgumentParser()
 parser.add_argument("--test")
+parser.add_argument("--light", action= 'store_true')
 args = parser.parse_args()
 
 start_date = date(2018, 4, 1)
@@ -189,7 +190,11 @@ if 'diab' in args.test:
 measures = Measures()
 measures.configure_dummy_data(population_size=10, legacy=True)
 measures.configure_disclosure_control(enabled=True)
-intervals = months(num_months(start_date, date.today())).starting_on(start_date)
+if args.light == True:
+    # Run a single year for test run
+    intervals = months(12).starting_on(start_date)
+else:
+    intervals = months(num_months(start_date, date.today())).starting_on(start_date)
 
 has_codelist_event = codelist_events.exists_for_patient()
 last_codelist_event = codelist_events.sort_by(codelist_events.date).last_for_patient()

--- a/analysis/measure_definition.py
+++ b/analysis/measure_definition.py
@@ -37,8 +37,12 @@ is_alive = patients.is_alive_on(INTERVAL.start_date)
 age = patients.age_on(INTERVAL.start_date)
 is_adult = (age >= 18) & (age < 120)
 
-registration = registrations.for_patient_on(INTERVAL.start_date)
-is_registered = registration.exists_for_patient()
+# Registered at the start of the interval and
+# only include practices that became TPP before the interval being measured
+is_registered = (registrations.exists_for_patient_on(INTERVAL.start_date) & 
+                  registrations.where(
+                    registrations.practice_systmone_go_live_date <= INTERVAL.start_date
+                    ).exists_for_patient())
 
 is_sex_recorded = patients.sex.is_in(["male", "female"])
 
@@ -224,8 +228,9 @@ measures.define_defaults(
 
 measures.define_measure(
     name="by_practice",
-    group_by={"practice": registration.practice_pseudo_id},
+    group_by={"practice": registrations.for_patient_on(INTERVAL.start_date).practice_pseudo_id}
 )
+
 measures.define_measure(
     name="by_snomedct_code",
     group_by={"snomedct_code": last_codelist_event.snomedct_code},

--- a/analysis/test_dataset.py
+++ b/analysis/test_dataset.py
@@ -25,7 +25,7 @@ test_data_options = {
         ],
         "expected_in_population": True,
         "expected_columns": {
-            "tests_outside_ref": True,
+            "numerator": True,
         },
     },
     # Vit d inside ref
@@ -48,7 +48,7 @@ test_data_options = {
         ],
         "expected_in_population": True,
         "expected_columns": {
-            "tests_outside_ref": False,
+            "numerator": False,
         },
     },
     3: {  # PSA outside ref
@@ -70,7 +70,7 @@ test_data_options = {
         ],
         "expected_in_population": True,
         "expected_columns": {
-            "tests_outside_ref": True,
+            "numerator": True,
         },
     },
     4: {  # PSA inside ref
@@ -92,7 +92,7 @@ test_data_options = {
         ],
         "expected_in_population": True,
         "expected_columns": {
-            "tests_outside_ref": False,
+            "numerator": False,
         },
     },
     5: {  # alt-mtx-ref within 1 months inside ref
@@ -118,7 +118,7 @@ test_data_options = {
         ],
         "expected_in_population": True,
         "expected_columns": {
-            "tests_outside_ref": False,
+            "numerator": False,
         },
     },
     6: {  # alt-mtx-ref outside 3 months inside ref
@@ -141,7 +141,7 @@ test_data_options = {
         ],
         "expected_in_population": False,
         "expected_columns": {
-            "tests_outside_ref": False,
+            "numerator": False,
         },
     },
     7: {  # alt-mtx-ref within 1 months, proxy null lower bound
@@ -167,7 +167,7 @@ test_data_options = {
         ],
         "expected_in_population": True,
         "expected_columns": {
-            "tests_outside_ref": False,
+            "numerator": False,
         },
     },
     8: {  # alt-mtx-ref within 1 months, proxy null upper bound
@@ -193,7 +193,7 @@ test_data_options = {
         ],
         "expected_in_population": False,
         "expected_columns": {
-            "tests_outside_ref": False,
+            "numerator": False,
         },
     },
     9: {  # hba1c_diab_mean numeric_value within 1 months
@@ -213,7 +213,7 @@ test_data_options = {
         ],
         "expected_in_population": True,
         "expected_columns": {
-            "mean": 4,
+            "numerator": 4,
         },
     },
     10: {  # hba1c_diab numeric_value outside 6 months
@@ -235,7 +235,7 @@ test_data_options = {
         ],
         "expected_in_population": True,
         "expected_columns": {
-            "has_codelist_event": False,
+            "numerator": False,
         },
     },
     11: {  # Negative control

--- a/analysis/write_processed_csv_files.py
+++ b/analysis/write_processed_csv_files.py
@@ -44,7 +44,7 @@ def get_deciles_table(df_measure_output):
 
     df_quantiles = (
         df_practice.groupby("interval_start")["ratio"]
-        .quantile(percentiles / 100)
+        .quantile(percentiles / 100, interpolation="nearest")
         .reset_index(name="value")
     )
 
@@ -153,14 +153,18 @@ def main(output_dir, codelist_path):
     codelist_path: string
         The path to the codelist
     """
-    df = pd.read_feather(output_dir / "measures.arrow")
 
     if args.sim:
+        df = pd.read_feather(output_dir / "measures.arrow")
         df['numerator'] = np.random.randint(0, 500, size = len(df))
         df['denominator'] = np.random.randint(500, 1000, size = len(df))
         df['ratio'] = df['numerator'] / df['denominator']
         suffix = '_sim'
+    elif args.light:
+        df = pd.read_feather(output_dir / "measures_light.arrow")
+        suffix = '_light'
     else:
+        df = pd.read_feather(output_dir / "measures.arrow")
         suffix = ''
 
     df["practice"] = df["practice"].astype("Int64")
@@ -195,6 +199,7 @@ if __name__ == "__main__":
     parser.add_argument("--test")
     parser.add_argument("--output-dir")
     parser.add_argument("--sim", action = 'store_true')
+    parser.add_argument("--light", action = 'store_true')
     args = parser.parse_args()
 
     # Specify test for cases that use multiple codelists e.g. hba1c_diabetes

--- a/generate_yaml.py
+++ b/generate_yaml.py
@@ -34,6 +34,17 @@ yaml_template = """
     outputs:
       highly_sensitive:
         measures: output/{test}_tests/measures.arrow
+  generate_measures_{test}_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/{test}_tests/measures_light.arrow
+        --
+        --test {test}
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/{test}_tests/measures_light.arrow
   generate_processed_data_{test}_tests:
     run: >
       python:latest 
@@ -47,20 +58,20 @@ yaml_template = """
         monthly_tables: output/{test}_tests/*table_counts_per_week*.csv
         code_table: output/{test}_tests/top_5_code_table.csv
         event_counts_table: output/{test}_tests/event_counts.csv
-  generate_processed_data_{test}_tests_sim:
+  generate_processed_data_{test}_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/{test}_tests
         --test {test}
-        --sim
+        --light
     needs:
-      [generate_measures_{test}_tests]
+      [generate_measures_{test}_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/{test}_tests/*per_week_per_practice_sim.csv
-        code_table: output/{test}_tests/top_5_code_table_sim.csv
-        event_counts_table: output/{test}_tests/event_counts_sim.csv
+        monthly_tables: output/{test}_tests/*per_week_per_practice_light.csv
+        code_table: output/{test}_tests/top_5_code_table_light.csv
+        event_counts_table: output/{test}_tests/event_counts_light.csv
   generate_dataset_test_{test}:
     run: >
         ehrql:v1 generate-dataset

--- a/project.yaml
+++ b/project.yaml
@@ -13,6 +13,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/alt_tests/measures.arrow
+  generate_measures_alt_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/alt_tests/measures_light.arrow
+        --
+        --test alt
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/alt_tests/measures_light.arrow
   generate_processed_data_alt_tests:
     run: >
       python:latest 
@@ -26,20 +37,20 @@ actions:
         monthly_tables: output/alt_tests/*table_counts_per_week*.csv
         code_table: output/alt_tests/top_5_code_table.csv
         event_counts_table: output/alt_tests/event_counts.csv
-  generate_processed_data_alt_tests_sim:
+  generate_processed_data_alt_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/alt_tests
         --test alt
-        --sim
+        --light
     needs:
-      [generate_measures_alt_tests]
+      [generate_measures_alt_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/alt_tests/*per_week_per_practice_sim.csv
-        code_table: output/alt_tests/top_5_code_table_sim.csv
-        event_counts_table: output/alt_tests/event_counts_sim.csv
+        monthly_tables: output/alt_tests/*per_week_per_practice_light.csv
+        code_table: output/alt_tests/top_5_code_table_light.csv
+        event_counts_table: output/alt_tests/event_counts_light.csv
   generate_dataset_test_alt:
     run: >
         ehrql:v1 generate-dataset
@@ -62,6 +73,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/chol_tests/measures.arrow
+  generate_measures_chol_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/chol_tests/measures_light.arrow
+        --
+        --test chol
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/chol_tests/measures_light.arrow
   generate_processed_data_chol_tests:
     run: >
       python:latest 
@@ -75,20 +97,20 @@ actions:
         monthly_tables: output/chol_tests/*table_counts_per_week*.csv
         code_table: output/chol_tests/top_5_code_table.csv
         event_counts_table: output/chol_tests/event_counts.csv
-  generate_processed_data_chol_tests_sim:
+  generate_processed_data_chol_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/chol_tests
         --test chol
-        --sim
+        --light
     needs:
-      [generate_measures_chol_tests]
+      [generate_measures_chol_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/chol_tests/*per_week_per_practice_sim.csv
-        code_table: output/chol_tests/top_5_code_table_sim.csv
-        event_counts_table: output/chol_tests/event_counts_sim.csv
+        monthly_tables: output/chol_tests/*per_week_per_practice_light.csv
+        code_table: output/chol_tests/top_5_code_table_light.csv
+        event_counts_table: output/chol_tests/event_counts_light.csv
   generate_dataset_test_chol:
     run: >
         ehrql:v1 generate-dataset
@@ -111,6 +133,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/hba1c_numeric_tests/measures.arrow
+  generate_measures_hba1c_numeric_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/hba1c_numeric_tests/measures_light.arrow
+        --
+        --test hba1c_numeric
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/hba1c_numeric_tests/measures_light.arrow
   generate_processed_data_hba1c_numeric_tests:
     run: >
       python:latest 
@@ -124,20 +157,20 @@ actions:
         monthly_tables: output/hba1c_numeric_tests/*table_counts_per_week*.csv
         code_table: output/hba1c_numeric_tests/top_5_code_table.csv
         event_counts_table: output/hba1c_numeric_tests/event_counts.csv
-  generate_processed_data_hba1c_numeric_tests_sim:
+  generate_processed_data_hba1c_numeric_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/hba1c_numeric_tests
         --test hba1c_numeric
-        --sim
+        --light
     needs:
-      [generate_measures_hba1c_numeric_tests]
+      [generate_measures_hba1c_numeric_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/hba1c_numeric_tests/*per_week_per_practice_sim.csv
-        code_table: output/hba1c_numeric_tests/top_5_code_table_sim.csv
-        event_counts_table: output/hba1c_numeric_tests/event_counts_sim.csv
+        monthly_tables: output/hba1c_numeric_tests/*per_week_per_practice_light.csv
+        code_table: output/hba1c_numeric_tests/top_5_code_table_light.csv
+        event_counts_table: output/hba1c_numeric_tests/event_counts_light.csv
   generate_dataset_test_hba1c_numeric:
     run: >
         ehrql:v1 generate-dataset
@@ -160,6 +193,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/rbc_tests/measures.arrow
+  generate_measures_rbc_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/rbc_tests/measures_light.arrow
+        --
+        --test rbc
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/rbc_tests/measures_light.arrow
   generate_processed_data_rbc_tests:
     run: >
       python:latest 
@@ -173,20 +217,20 @@ actions:
         monthly_tables: output/rbc_tests/*table_counts_per_week*.csv
         code_table: output/rbc_tests/top_5_code_table.csv
         event_counts_table: output/rbc_tests/event_counts.csv
-  generate_processed_data_rbc_tests_sim:
+  generate_processed_data_rbc_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/rbc_tests
         --test rbc
-        --sim
+        --light
     needs:
-      [generate_measures_rbc_tests]
+      [generate_measures_rbc_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/rbc_tests/*per_week_per_practice_sim.csv
-        code_table: output/rbc_tests/top_5_code_table_sim.csv
-        event_counts_table: output/rbc_tests/event_counts_sim.csv
+        monthly_tables: output/rbc_tests/*per_week_per_practice_light.csv
+        code_table: output/rbc_tests/top_5_code_table_light.csv
+        event_counts_table: output/rbc_tests/event_counts_light.csv
   generate_dataset_test_rbc:
     run: >
         ehrql:v1 generate-dataset
@@ -209,6 +253,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/sodium_tests/measures.arrow
+  generate_measures_sodium_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/sodium_tests/measures_light.arrow
+        --
+        --test sodium
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/sodium_tests/measures_light.arrow
   generate_processed_data_sodium_tests:
     run: >
       python:latest 
@@ -222,20 +277,20 @@ actions:
         monthly_tables: output/sodium_tests/*table_counts_per_week*.csv
         code_table: output/sodium_tests/top_5_code_table.csv
         event_counts_table: output/sodium_tests/event_counts.csv
-  generate_processed_data_sodium_tests_sim:
+  generate_processed_data_sodium_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/sodium_tests
         --test sodium
-        --sim
+        --light
     needs:
-      [generate_measures_sodium_tests]
+      [generate_measures_sodium_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/sodium_tests/*per_week_per_practice_sim.csv
-        code_table: output/sodium_tests/top_5_code_table_sim.csv
-        event_counts_table: output/sodium_tests/event_counts_sim.csv
+        monthly_tables: output/sodium_tests/*per_week_per_practice_light.csv
+        code_table: output/sodium_tests/top_5_code_table_light.csv
+        event_counts_table: output/sodium_tests/event_counts_light.csv
   generate_dataset_test_sodium:
     run: >
         ehrql:v1 generate-dataset
@@ -258,6 +313,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/systol_tests/measures.arrow
+  generate_measures_systol_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/systol_tests/measures_light.arrow
+        --
+        --test systol
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/systol_tests/measures_light.arrow
   generate_processed_data_systol_tests:
     run: >
       python:latest 
@@ -271,20 +337,20 @@ actions:
         monthly_tables: output/systol_tests/*table_counts_per_week*.csv
         code_table: output/systol_tests/top_5_code_table.csv
         event_counts_table: output/systol_tests/event_counts.csv
-  generate_processed_data_systol_tests_sim:
+  generate_processed_data_systol_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/systol_tests
         --test systol
-        --sim
+        --light
     needs:
-      [generate_measures_systol_tests]
+      [generate_measures_systol_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/systol_tests/*per_week_per_practice_sim.csv
-        code_table: output/systol_tests/top_5_code_table_sim.csv
-        event_counts_table: output/systol_tests/event_counts_sim.csv
+        monthly_tables: output/systol_tests/*per_week_per_practice_light.csv
+        code_table: output/systol_tests/top_5_code_table_light.csv
+        event_counts_table: output/systol_tests/event_counts_light.csv
   generate_dataset_test_systol:
     run: >
         ehrql:v1 generate-dataset
@@ -307,6 +373,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/vit_d_tests/measures.arrow
+  generate_measures_vit_d_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/vit_d_tests/measures_light.arrow
+        --
+        --test vit_d
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/vit_d_tests/measures_light.arrow
   generate_processed_data_vit_d_tests:
     run: >
       python:latest 
@@ -320,20 +397,20 @@ actions:
         monthly_tables: output/vit_d_tests/*table_counts_per_week*.csv
         code_table: output/vit_d_tests/top_5_code_table.csv
         event_counts_table: output/vit_d_tests/event_counts.csv
-  generate_processed_data_vit_d_tests_sim:
+  generate_processed_data_vit_d_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/vit_d_tests
         --test vit_d
-        --sim
+        --light
     needs:
-      [generate_measures_vit_d_tests]
+      [generate_measures_vit_d_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/vit_d_tests/*per_week_per_practice_sim.csv
-        code_table: output/vit_d_tests/top_5_code_table_sim.csv
-        event_counts_table: output/vit_d_tests/event_counts_sim.csv
+        monthly_tables: output/vit_d_tests/*per_week_per_practice_light.csv
+        code_table: output/vit_d_tests/top_5_code_table_light.csv
+        event_counts_table: output/vit_d_tests/event_counts_light.csv
   generate_dataset_test_vit_d:
     run: >
         ehrql:v1 generate-dataset
@@ -356,6 +433,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/vit_d_ref_tests/measures.arrow
+  generate_measures_vit_d_ref_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/vit_d_ref_tests/measures_light.arrow
+        --
+        --test vit_d_ref
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/vit_d_ref_tests/measures_light.arrow
   generate_processed_data_vit_d_ref_tests:
     run: >
       python:latest 
@@ -369,20 +457,20 @@ actions:
         monthly_tables: output/vit_d_ref_tests/*table_counts_per_week*.csv
         code_table: output/vit_d_ref_tests/top_5_code_table.csv
         event_counts_table: output/vit_d_ref_tests/event_counts.csv
-  generate_processed_data_vit_d_ref_tests_sim:
+  generate_processed_data_vit_d_ref_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/vit_d_ref_tests
         --test vit_d_ref
-        --sim
+        --light
     needs:
-      [generate_measures_vit_d_ref_tests]
+      [generate_measures_vit_d_ref_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/vit_d_ref_tests/*per_week_per_practice_sim.csv
-        code_table: output/vit_d_ref_tests/top_5_code_table_sim.csv
-        event_counts_table: output/vit_d_ref_tests/event_counts_sim.csv
+        monthly_tables: output/vit_d_ref_tests/*per_week_per_practice_light.csv
+        code_table: output/vit_d_ref_tests/top_5_code_table_light.csv
+        event_counts_table: output/vit_d_ref_tests/event_counts_light.csv
   generate_dataset_test_vit_d_ref:
     run: >
         ehrql:v1 generate-dataset
@@ -405,6 +493,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/psa_tests/measures.arrow
+  generate_measures_psa_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/psa_tests/measures_light.arrow
+        --
+        --test psa
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/psa_tests/measures_light.arrow
   generate_processed_data_psa_tests:
     run: >
       python:latest 
@@ -418,20 +517,20 @@ actions:
         monthly_tables: output/psa_tests/*table_counts_per_week*.csv
         code_table: output/psa_tests/top_5_code_table.csv
         event_counts_table: output/psa_tests/event_counts.csv
-  generate_processed_data_psa_tests_sim:
+  generate_processed_data_psa_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/psa_tests
         --test psa
-        --sim
+        --light
     needs:
-      [generate_measures_psa_tests]
+      [generate_measures_psa_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/psa_tests/*per_week_per_practice_sim.csv
-        code_table: output/psa_tests/top_5_code_table_sim.csv
-        event_counts_table: output/psa_tests/event_counts_sim.csv
+        monthly_tables: output/psa_tests/*per_week_per_practice_light.csv
+        code_table: output/psa_tests/top_5_code_table_light.csv
+        event_counts_table: output/psa_tests/event_counts_light.csv
   generate_dataset_test_psa:
     run: >
         ehrql:v1 generate-dataset
@@ -454,6 +553,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/psa_ref_tests/measures.arrow
+  generate_measures_psa_ref_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/psa_ref_tests/measures_light.arrow
+        --
+        --test psa_ref
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/psa_ref_tests/measures_light.arrow
   generate_processed_data_psa_ref_tests:
     run: >
       python:latest 
@@ -467,20 +577,20 @@ actions:
         monthly_tables: output/psa_ref_tests/*table_counts_per_week*.csv
         code_table: output/psa_ref_tests/top_5_code_table.csv
         event_counts_table: output/psa_ref_tests/event_counts.csv
-  generate_processed_data_psa_ref_tests_sim:
+  generate_processed_data_psa_ref_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/psa_ref_tests
         --test psa_ref
-        --sim
+        --light
     needs:
-      [generate_measures_psa_ref_tests]
+      [generate_measures_psa_ref_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/psa_ref_tests/*per_week_per_practice_sim.csv
-        code_table: output/psa_ref_tests/top_5_code_table_sim.csv
-        event_counts_table: output/psa_ref_tests/event_counts_sim.csv
+        monthly_tables: output/psa_ref_tests/*per_week_per_practice_light.csv
+        code_table: output/psa_ref_tests/top_5_code_table_light.csv
+        event_counts_table: output/psa_ref_tests/event_counts_light.csv
   generate_dataset_test_psa_ref:
     run: >
         ehrql:v1 generate-dataset
@@ -503,6 +613,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/hba1c_diab_tests/measures.arrow
+  generate_measures_hba1c_diab_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/hba1c_diab_tests/measures_light.arrow
+        --
+        --test hba1c_diab
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/hba1c_diab_tests/measures_light.arrow
   generate_processed_data_hba1c_diab_tests:
     run: >
       python:latest 
@@ -516,20 +637,20 @@ actions:
         monthly_tables: output/hba1c_diab_tests/*table_counts_per_week*.csv
         code_table: output/hba1c_diab_tests/top_5_code_table.csv
         event_counts_table: output/hba1c_diab_tests/event_counts.csv
-  generate_processed_data_hba1c_diab_tests_sim:
+  generate_processed_data_hba1c_diab_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/hba1c_diab_tests
         --test hba1c_diab
-        --sim
+        --light
     needs:
-      [generate_measures_hba1c_diab_tests]
+      [generate_measures_hba1c_diab_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/hba1c_diab_tests/*per_week_per_practice_sim.csv
-        code_table: output/hba1c_diab_tests/top_5_code_table_sim.csv
-        event_counts_table: output/hba1c_diab_tests/event_counts_sim.csv
+        monthly_tables: output/hba1c_diab_tests/*per_week_per_practice_light.csv
+        code_table: output/hba1c_diab_tests/top_5_code_table_light.csv
+        event_counts_table: output/hba1c_diab_tests/event_counts_light.csv
   generate_dataset_test_hba1c_diab:
     run: >
         ehrql:v1 generate-dataset
@@ -552,6 +673,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/hba1c_diab_mean_tests/measures.arrow
+  generate_measures_hba1c_diab_mean_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/hba1c_diab_mean_tests/measures_light.arrow
+        --
+        --test hba1c_diab_mean
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/hba1c_diab_mean_tests/measures_light.arrow
   generate_processed_data_hba1c_diab_mean_tests:
     run: >
       python:latest 
@@ -565,20 +697,20 @@ actions:
         monthly_tables: output/hba1c_diab_mean_tests/*table_counts_per_week*.csv
         code_table: output/hba1c_diab_mean_tests/top_5_code_table.csv
         event_counts_table: output/hba1c_diab_mean_tests/event_counts.csv
-  generate_processed_data_hba1c_diab_mean_tests_sim:
+  generate_processed_data_hba1c_diab_mean_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/hba1c_diab_mean_tests
         --test hba1c_diab_mean
-        --sim
+        --light
     needs:
-      [generate_measures_hba1c_diab_mean_tests]
+      [generate_measures_hba1c_diab_mean_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/hba1c_diab_mean_tests/*per_week_per_practice_sim.csv
-        code_table: output/hba1c_diab_mean_tests/top_5_code_table_sim.csv
-        event_counts_table: output/hba1c_diab_mean_tests/event_counts_sim.csv
+        monthly_tables: output/hba1c_diab_mean_tests/*per_week_per_practice_light.csv
+        code_table: output/hba1c_diab_mean_tests/top_5_code_table_light.csv
+        event_counts_table: output/hba1c_diab_mean_tests/event_counts_light.csv
   generate_dataset_test_hba1c_diab_mean:
     run: >
         ehrql:v1 generate-dataset
@@ -601,6 +733,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/alt_mtx_tests/measures.arrow
+  generate_measures_alt_mtx_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/alt_mtx_tests/measures_light.arrow
+        --
+        --test alt_mtx
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/alt_mtx_tests/measures_light.arrow
   generate_processed_data_alt_mtx_tests:
     run: >
       python:latest 
@@ -614,20 +757,20 @@ actions:
         monthly_tables: output/alt_mtx_tests/*table_counts_per_week*.csv
         code_table: output/alt_mtx_tests/top_5_code_table.csv
         event_counts_table: output/alt_mtx_tests/event_counts.csv
-  generate_processed_data_alt_mtx_tests_sim:
+  generate_processed_data_alt_mtx_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/alt_mtx_tests
         --test alt_mtx
-        --sim
+        --light
     needs:
-      [generate_measures_alt_mtx_tests]
+      [generate_measures_alt_mtx_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/alt_mtx_tests/*per_week_per_practice_sim.csv
-        code_table: output/alt_mtx_tests/top_5_code_table_sim.csv
-        event_counts_table: output/alt_mtx_tests/event_counts_sim.csv
+        monthly_tables: output/alt_mtx_tests/*per_week_per_practice_light.csv
+        code_table: output/alt_mtx_tests/top_5_code_table_light.csv
+        event_counts_table: output/alt_mtx_tests/event_counts_light.csv
   generate_dataset_test_alt_mtx:
     run: >
         ehrql:v1 generate-dataset
@@ -650,6 +793,17 @@ actions:
     outputs:
       highly_sensitive:
         measures: output/alt_mtx_ref_tests/measures.arrow
+  generate_measures_alt_mtx_ref_tests_light:
+    run: >
+      ehrql:v1 generate-measures
+        analysis/measure_definition.py
+        --output output/alt_mtx_ref_tests/measures_light.arrow
+        --
+        --test alt_mtx_ref
+        --light
+    outputs:
+      highly_sensitive:
+        measures: output/alt_mtx_ref_tests/measures_light.arrow
   generate_processed_data_alt_mtx_ref_tests:
     run: >
       python:latest 
@@ -663,20 +817,20 @@ actions:
         monthly_tables: output/alt_mtx_ref_tests/*table_counts_per_week*.csv
         code_table: output/alt_mtx_ref_tests/top_5_code_table.csv
         event_counts_table: output/alt_mtx_ref_tests/event_counts.csv
-  generate_processed_data_alt_mtx_ref_tests_sim:
+  generate_processed_data_alt_mtx_ref_tests_light:
     run: >
       python:latest 
         analysis/write_processed_csv_files.py
         --output-dir output/alt_mtx_ref_tests
         --test alt_mtx_ref
-        --sim
+        --light
     needs:
-      [generate_measures_alt_mtx_ref_tests]
+      [generate_measures_alt_mtx_ref_tests_light]
     outputs:
       moderately_sensitive:
-        monthly_tables: output/alt_mtx_ref_tests/*per_week_per_practice_sim.csv
-        code_table: output/alt_mtx_ref_tests/top_5_code_table_sim.csv
-        event_counts_table: output/alt_mtx_ref_tests/event_counts_sim.csv
+        monthly_tables: output/alt_mtx_ref_tests/*per_week_per_practice_light.csv
+        code_table: output/alt_mtx_ref_tests/top_5_code_table_light.csv
+        event_counts_table: output/alt_mtx_ref_tests/event_counts_light.csv
   generate_dataset_test_alt_mtx_ref:
     run: >
         ehrql:v1 generate-dataset


### PR DESCRIPTION
- Only use practices that were registered as TPP at the time of interval
- Add light version of jobs that runs a single year