### PR TITLE
List pathology measures first in the dashboard dropdown

### DIFF
--- a/app/measures.py
+++ b/app/measures.py
@@ -17,6 +17,7 @@ MEDIAN = "Median"
 @dataclasses.dataclass
 class Measure:
     name: str
+    is_pathology: bool
     explanation: str
     caveats: str
     classification: str
@@ -116,6 +117,7 @@ class OSJobsRepository:
 
         return Measure(
             name,
+            record["is_pathology"],
             record["explanation"],
             record["caveats"],
             record["classification"],

--- a/app/measures.py
+++ b/app/measures.py
@@ -128,8 +128,17 @@ class OSJobsRepository:
         )
 
     def list(self):
-        """List the names of all the measures in the repository."""
-        return sorted(self._records.keys())
+        """
+        List the names of all the measures in the repository.
+        Pathology measures are listed first alphabetically, followed by other measures alphabetically.
+        """
+        pathology_measures = [
+            name for name, record in self._records.items() if record["is_pathology"]
+        ]
+        other_measures = [
+            name for name, record in self._records.items() if not record["is_pathology"]
+        ]
+        return sorted(pathology_measures) + sorted(other_measures)
 
 
 def _get_counts(counts_table_url):

--- a/app/measures.yaml
+++ b/app/measures.yaml
@@ -1,4 +1,5 @@
 - name: Blood Pressure monitoring rate
+  is_pathology: false
   explanation: >
     A commonly-used assessment used to identify patients with hypertension or to ensure optimal treatment for those with known hypertension.
     This helps ensure appropriate treatment, with the aim of reducing long term risks of complications from hypertension such as stroke,
@@ -14,6 +15,7 @@
   deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273Y8PM2QYPWBDXWT433/
 
 - name: Cholesterol testing rate
+  is_pathology: true
   explanation: >
     A commonly-used blood test used as part of a routine cardiovascular disease 10 year risk assessment
     and also to identify patients with lipid disorders (e.g. familial hypercholesterolaemia).
@@ -30,6 +32,7 @@
   deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273Y8PM2QYPWBDXWT433/
 
 - name: Liver Function - Alanine Transferaminase (ALT) testing rate
+  is_pathology: true
   explanation: >
     An ALT blood test is one of a group of liver function tests (LFTs) which are used to detect problems with the function of the liver.
     It is often used to monitor patients on medications which may affect the liver or which rely on the liver to break them down within the body.
@@ -46,6 +49,7 @@
   deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12739P6B7Z00QAJBTBKK3/
 
 - name: Red Blood Cell (RBC) count testing rate
+  is_pathology: true
   explanation: >
     RBC is completed as part of a group of tests referred to as a full blood count (FBC),
     used to detect a variety of disorders of the blood, such as anaemia and infection.
@@ -60,6 +64,7 @@
   deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273RP68K1YM9TYRA2FBD/
 
 - name: Glycated Haemoglobin A1c (HbA1c) testing rate
+  is_pathology: true
   explanation: >
     HbA1c is a long term indicator of diabetes control.
     NICE guidelines recommend that individuals with diabetes have their HbA1c measured at least twice a year.
@@ -75,6 +80,7 @@
   deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273K1QJM5EQ7238X7P3S/
 
 - name: Renal Function - Sodium testing rate
+  is_pathology: true
   explanation: >
     Sodium is completed as part of a group of tests referred to as a renal profile,
     used to detect a variety of disorders of the kidneys.


### PR DESCRIPTION
Related slack thread here: https://bennettoxford.slack.com/archives/C081EMDSZ2Q/p1754573861891969

Since this project is OpenPathology, it makes sense for a blood test to be shown as the default option on the dashboard.

I'm not sure if this is to be handled by the presentation layer or the repository, but I've decided to place the change in the repository since the repository currently already sorts measure names.