### PR TITLE
Do not cache the repository

### DIFF
--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -2,7 +2,6 @@ import measures
 import streamlit
 
 
-@streamlit.cache_resource
 def get_repository():
     return measures.OSJobsRepository()
 


### PR DESCRIPTION
We would like to cache the repository for efficiency purposes, but caching might be preventing changes to the repository being reflected on the community cloud link.

We can cache the repository once more when the person capable of rebooting the app is available to take reboot requests.