### PR TITLE
Use Jobserver API to provide filenames

### DIFF
--- a/app/measures.py
+++ b/app/measures.py
@@ -1,8 +1,11 @@
 import dataclasses
 import pathlib
+import re
+import urllib.parse
 
 import altair
 import pandas
+import requests
 import structlog
 import yaml
 
@@ -90,9 +93,37 @@ class Measure:
         return chart
 
 
+class OSJobsWorkspace:
+    def __init__(
+        self, endpoint, file_structure="output/(?P<shorthand>[^/]+)/(?P<name>.+)"
+    ):
+        self.base_url = "https://jobs.opensafely.org/"
+        self.endpoint_url = urllib.parse.urljoin(self.base_url, endpoint)
+        self.file_structure = file_structure
+
+    def get_file_urls(self):
+        response = requests.get(self.endpoint_url)
+        file_list = response.json()["files"]
+        name_to_url = {
+            file["name"]: urllib.parse.urljoin(self.base_url, file["url"])
+            for file in file_list
+        }
+        file_urls = {
+            key: url for name, url in name_to_url.items() if (key := self.get_key(name))
+        }
+        return file_urls
+
+    def get_key(self, file_name):
+        match = re.match(self.file_structure, file_name)
+        if not match:
+            return None
+        return (match.group("shorthand"), match.group("name"))
+
+
 class OSJobsRepository:
-    def __init__(self):
+    def __init__(self, file_urls):
         path = pathlib.Path(__file__).parent.joinpath("measures.yaml")
+        self._file_urls = file_urls
         self._records = {r["name"]: r for r in yaml.load(path.read_text(), yaml.Loader)}
         self._measures = {}  # the repository
 
@@ -111,9 +142,9 @@ class OSJobsRepository:
 
         # The following helpers don't need access to instance attributes, so we define
         # them as functions rather than as methods. Doing so makes them easier to mock.
-        counts = _get_counts(record["counts_table_url"])
-        top_5_codes_table = _get_top_5_codes_table(record["top_5_codes_table_url"])
-        deciles_table = _get_deciles_table(record["deciles_table_url"])
+        counts = self._get_counts(record["shorthand"])
+        top_5_codes_table = self._get_top_5_codes_table(record["shorthand"])
+        deciles_table = self._get_deciles_table(record["shorthand"])
 
         return Measure(
             name,
@@ -125,6 +156,21 @@ class OSJobsRepository:
             counts["total_events"],
             top_5_codes_table,
             deciles_table,
+        )
+
+    def _get_counts(self, shorthand):
+        return _get_counts(self._file_urls[(shorthand, "event_counts.csv")])
+
+    def _get_top_5_codes_table(self, shorthand):
+        return _get_top_5_codes_table(
+            self._file_urls[(shorthand, "top_5_code_table.csv")]
+        )
+
+    def _get_deciles_table(self, shorthand):
+        return _get_deciles_table(
+            self._file_urls[
+                (shorthand, "deciles_table_counts_per_week_per_practice.csv")
+            ]
         )
 
     def list(self):

--- a/app/measures.yaml
+++ b/app/measures.yaml
@@ -1,4 +1,5 @@
 - name: Blood Pressure monitoring rate
+  shorthand: systolic_bp
   is_pathology: false
   explanation: >
     A commonly-used assessment used to identify patients with hypertension or to ensure optimal treatment for those with known hypertension.
@@ -10,11 +11,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: sustained drop
   codelist_url: https://www.opencodelists.org/codelist/opensafely/systolic-blood-pressure-qof/3572b5fb/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274J5CHBHZYTD38Q4X3Z/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGM5TB62ZPT4D3T7A56F/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273Y8PM2QYPWBDXWT433/
 
 - name: Cholesterol testing rate
+  shorthand: cholesterol
   is_pathology: true
   explanation: >
     A commonly-used blood test used as part of a routine cardiovascular disease 10 year risk assessment
@@ -27,11 +26,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/cholesterol-tests/0f1b2a4c/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12745NSRAF6CSV2Y5587V/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGN5YJM0VRCGQ979B68K/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273GGXHAVCHAWF9MZMPY/
 
 - name: Liver Function - Alanine Transferaminase (ALT) testing rate
+  shorthand: alt
   is_pathology: true
   explanation: >
     An ALT blood test is one of a group of liver function tests (LFTs) which are used to detect problems with the function of the liver.
@@ -44,11 +41,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/alanine-aminotransferase-alt-tests/2298df3e/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ127420DXX35BM0MMQNW8N/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGKSB1ANPP4X5V2FM3FR/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12739P6B7Z00QAJBTBKK3/
 
 - name: Red Blood Cell (RBC) count testing rate
+  shorthand: rbc
   is_pathology: true
   explanation: >
     RBC is completed as part of a group of tests referred to as a full blood count (FBC),
@@ -59,11 +54,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/red-blood-cell-rbc-tests/576a859e/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274E1QDEFYVGPFH13GBV/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGM2Q5PXN17JG59HZFRQ/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273RP68K1YM9TYRA2FBD/
 
 - name: Glycated Haemoglobin A1c (HbA1c) testing rate
+  shorthand: hba1c
   is_pathology: true
   explanation: >
     HbA1c is a long term indicator of diabetes control.
@@ -75,11 +68,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/glycated-haemoglobin-hba1c-tests/3e5b1269/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12749JZ938746AV8XCPZ3/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMVQ62NGNM403MK32Z7/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273K1QJM5EQ7238X7P3S/
 
 - name: Renal Function - Sodium testing rate
+  shorthand: sodium
   is_pathology: true
   explanation: >
     Sodium is completed as part of a group of tests referred to as a renal profile,
@@ -91,6 +82,3 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/sodium-tests-numerical-value/32bff605/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274G3QAPB7QP12QMH4A6/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMADFDX6MCPE2P9DHM2/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273T25NQB2E84Y4X8HH2/

--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -3,7 +3,10 @@ import streamlit
 
 
 def get_repository():
-    return measures.OSJobsRepository()
+    workspace = measures.OSJobsWorkspace(
+        "api/v2/workspaces/sro-key-measures-dashboard/snapshots/31"
+    )
+    return measures.OSJobsRepository(workspace.get_file_urls())
 
 
 def main():


### PR DESCRIPTION
This eliminates the human error in copy and pasting file URLs. Would not have been necessary if I didn't have an atrocious lack of ability to copy and paste, but I do, so this gives me peace of mind.