### PR TITLE
Use Jobserver API to provide filenames

### DIFF
--- a/app/file_urls.yaml
+++ b/app/file_urls.yaml
@@ -1,0 +1,44 @@
+alt:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ127420DXX35BM0MMQNW8N/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12739P6B7Z00QAJBTBKK3/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGKSB1ANPP4X5V2FM3FR/
+asthma:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12744QQFDXNKDZFM6D9PA/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273E5ZJQ7TQ4EREQZXHV/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMZPFNMFFPNJ0Q7AQW0/
+cholesterol:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12745NSRAF6CSV2Y5587V/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273GGXHAVCHAWF9MZMPY/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGN5YJM0VRCGQ979B68K/
+copd:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12747S076CXG4DSYG3365/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273HBSH9AYT8V9FRB6S6/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGN6HQTMHD0ZZEK9BWMZ/
+hba1c:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12749JZ938746AV8XCPZ3/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273K1QJM5EQ7238X7P3S/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMVQ62NGNM403MK32Z7/
+medication_review:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274AQTKME4H35S4DC2GN/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273NXRK2Z8C05BH3K235/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMRGETC544D3BZCZX0N/
+qrisk2:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274CPVJ4PC1NN2QE8QG0/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273QS8ACSZMJENEFZ0BQ/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMMMX7YMJQ80F54E56Y/
+rbc:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274E1QDEFYVGPFH13GBV/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273RP68K1YM9TYRA2FBD/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMGW5P6WH7TXV878FFK/
+sodium:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274G3QAPB7QP12QMH4A6/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273T25NQB2E84Y4X8HH2/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMADFDX6MCPE2P9DHM2/
+systolic_bp:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274J5CHBHZYTD38Q4X3Z/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273Y8PM2QYPWBDXWT433/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGM5TB62ZPT4D3T7A56F/
+tsh:
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274KHCEV4VV1RFJPVJ5B/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12740V6XDKZY796V0MHWN/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGM2Q5PXN17JG59HZFRQ/

--- a/app/get_file_urls.py
+++ b/app/get_file_urls.py
@@ -1,0 +1,55 @@
+import re
+import urllib.parse
+
+import requests
+import yaml
+
+
+BASE_URL = "https://jobs.opensafely.org/"
+WORKSPACE_ENDPOINT = urllib.parse.urljoin(
+    BASE_URL, "api/v2/workspaces/sro-key-measures-dashboard/snapshots/31"
+)
+
+FILENAME_TO_ALIAS = {
+    "event_counts.csv": "counts_table",
+    "top_5_code_table.csv": "top_5_codes_table",
+    "deciles_table_counts_per_week_per_practice.csv": "deciles_table",
+}
+
+
+def get_key(file_name):
+    match = re.match("output/(?P<shorthand>[^/]+)/(?P<name>.+)", file_name)
+    if not match:
+        return None
+    shorthand, name = match.groups()
+    try:
+        return (shorthand, FILENAME_TO_ALIAS[name])
+    except KeyError:
+        return None
+
+
+def get_file_urls():
+    response = requests.get(WORKSPACE_ENDPOINT)
+    file_list = response.json()["files"]
+    name_to_url = {
+        file["name"]: urllib.parse.urljoin(BASE_URL, file["url"]) for file in file_list
+    }
+    file_urls = {
+        key: url for name, url in name_to_url.items() if (key := get_key(name))
+    }
+    return file_urls
+
+
+def write_file_urls_to_yaml(file_urls):
+    files_by_shorthand = {}
+    for (shorthand, alias), url in file_urls.items():
+        if shorthand not in files_by_shorthand:
+            files_by_shorthand[shorthand] = {}
+        files_by_shorthand[shorthand][alias] = url
+    with open("app/file_urls.yaml", "w") as f:
+        yaml.dump(files_by_shorthand, f)
+
+
+if __name__ == "__main__":
+    file_urls = get_file_urls()
+    write_file_urls_to_yaml(file_urls)

--- a/app/measures.py
+++ b/app/measures.py
@@ -1,11 +1,8 @@
 import dataclasses
 import pathlib
-import re
-import urllib.parse
 
 import altair
 import pandas
-import requests
 import structlog
 import yaml
 
@@ -93,37 +90,9 @@ class Measure:
         return chart
 
 
-class OSJobsWorkspace:
-    def __init__(
-        self, endpoint, file_structure="output/(?P<shorthand>[^/]+)/(?P<name>.+)"
-    ):
-        self.base_url = "https://jobs.opensafely.org/"
-        self.endpoint_url = urllib.parse.urljoin(self.base_url, endpoint)
-        self.file_structure = file_structure
-
-    def get_file_urls(self):
-        response = requests.get(self.endpoint_url)
-        file_list = response.json()["files"]
-        name_to_url = {
-            file["name"]: urllib.parse.urljoin(self.base_url, file["url"])
-            for file in file_list
-        }
-        file_urls = {
-            key: url for name, url in name_to_url.items() if (key := self.get_key(name))
-        }
-        return file_urls
-
-    def get_key(self, file_name):
-        match = re.match(self.file_structure, file_name)
-        if not match:
-            return None
-        return (match.group("shorthand"), match.group("name"))
-
-
 class OSJobsRepository:
-    def __init__(self, file_urls):
+    def __init__(self):
         path = pathlib.Path(__file__).parent.joinpath("measures.yaml")
-        self._file_urls = file_urls
         self._records = {r["name"]: r for r in yaml.load(path.read_text(), yaml.Loader)}
         self._measures = {}  # the repository
 
@@ -142,9 +111,9 @@ class OSJobsRepository:
 
         # The following helpers don't need access to instance attributes, so we define
         # them as functions rather than as methods. Doing so makes them easier to mock.
-        counts = self._get_counts(record["shorthand"])
-        top_5_codes_table = self._get_top_5_codes_table(record["shorthand"])
-        deciles_table = self._get_deciles_table(record["shorthand"])
+        counts = _get_counts(record["counts_table_url"])
+        top_5_codes_table = _get_top_5_codes_table(record["top_5_codes_table_url"])
+        deciles_table = _get_deciles_table(record["deciles_table_url"])
 
         return Measure(
             name,
@@ -156,21 +125,6 @@ class OSJobsRepository:
             counts["total_events"],
             top_5_codes_table,
             deciles_table,
-        )
-
-    def _get_counts(self, shorthand):
-        return _get_counts(self._file_urls[(shorthand, "event_counts.csv")])
-
-    def _get_top_5_codes_table(self, shorthand):
-        return _get_top_5_codes_table(
-            self._file_urls[(shorthand, "top_5_code_table.csv")]
-        )
-
-    def _get_deciles_table(self, shorthand):
-        return _get_deciles_table(
-            self._file_urls[
-                (shorthand, "deciles_table_counts_per_week_per_practice.csv")
-            ]
         )
 
     def list(self):

--- a/app/measures.py
+++ b/app/measures.py
@@ -93,7 +93,9 @@ class Measure:
 class OSJobsRepository:
     def __init__(self):
         path = pathlib.Path(__file__).parent.joinpath("measures.yaml")
+        file_urls_path = pathlib.Path(__file__).parent.joinpath("file_urls.yaml")
         self._records = {r["name"]: r for r in yaml.load(path.read_text(), yaml.Loader)}
+        self._file_urls = yaml.load(file_urls_path.read_text(), yaml.Loader)
         self._measures = {}  # the repository
 
     def get(self, name):
@@ -103,6 +105,9 @@ class OSJobsRepository:
             self._measures[name] = self._construct(name)
         return self._measures[name]
 
+    def _get_file_url(self, shorthand, key):
+        return self._file_urls[shorthand][key + "_url"]
+
     def _construct(self, name):
         """Construct the measure with the given name from information stored on the
         local file system and on OS Jobs."""
@@ -111,9 +116,13 @@ class OSJobsRepository:
 
         # The following helpers don't need access to instance attributes, so we define
         # them as functions rather than as methods. Doing so makes them easier to mock.
-        counts = _get_counts(record["counts_table_url"])
-        top_5_codes_table = _get_top_5_codes_table(record["top_5_codes_table_url"])
-        deciles_table = _get_deciles_table(record["deciles_table_url"])
+        counts = _get_counts(self._get_file_url(record["shorthand"], "counts_table"))
+        top_5_codes_table = _get_top_5_codes_table(
+            self._get_file_url(record["shorthand"], "top_5_codes_table")
+        )
+        deciles_table = _get_deciles_table(
+            self._get_file_url(record["shorthand"], "deciles_table")
+        )
 
         return Measure(
             name,

--- a/app/measures.yaml
+++ b/app/measures.yaml
@@ -1,5 +1,4 @@
 - name: Blood Pressure monitoring rate
-  shorthand: systolic_bp
   is_pathology: false
   explanation: >
     A commonly-used assessment used to identify patients with hypertension or to ensure optimal treatment for those with known hypertension.
@@ -11,9 +10,11 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: sustained drop
   codelist_url: https://www.opencodelists.org/codelist/opensafely/systolic-blood-pressure-qof/3572b5fb/
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274J5CHBHZYTD38Q4X3Z/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGM5TB62ZPT4D3T7A56F/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273Y8PM2QYPWBDXWT433/
 
 - name: Cholesterol testing rate
-  shorthand: cholesterol
   is_pathology: true
   explanation: >
     A commonly-used blood test used as part of a routine cardiovascular disease 10 year risk assessment
@@ -26,9 +27,11 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/cholesterol-tests/0f1b2a4c/
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12745NSRAF6CSV2Y5587V/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGN5YJM0VRCGQ979B68K/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273GGXHAVCHAWF9MZMPY/
 
 - name: Liver Function - Alanine Transferaminase (ALT) testing rate
-  shorthand: alt
   is_pathology: true
   explanation: >
     An ALT blood test is one of a group of liver function tests (LFTs) which are used to detect problems with the function of the liver.
@@ -41,9 +44,11 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/alanine-aminotransferase-alt-tests/2298df3e/
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ127420DXX35BM0MMQNW8N/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGKSB1ANPP4X5V2FM3FR/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12739P6B7Z00QAJBTBKK3/
 
 - name: Red Blood Cell (RBC) count testing rate
-  shorthand: rbc
   is_pathology: true
   explanation: >
     RBC is completed as part of a group of tests referred to as a full blood count (FBC),
@@ -54,9 +59,11 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/red-blood-cell-rbc-tests/576a859e/
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274E1QDEFYVGPFH13GBV/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGM2Q5PXN17JG59HZFRQ/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273RP68K1YM9TYRA2FBD/
 
 - name: Glycated Haemoglobin A1c (HbA1c) testing rate
-  shorthand: hba1c
   is_pathology: true
   explanation: >
     HbA1c is a long term indicator of diabetes control.
@@ -68,9 +75,11 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/glycated-haemoglobin-hba1c-tests/3e5b1269/
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12749JZ938746AV8XCPZ3/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMVQ62NGNM403MK32Z7/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273K1QJM5EQ7238X7P3S/
 
 - name: Renal Function - Sodium testing rate
-  shorthand: sodium
   is_pathology: true
   explanation: >
     Sodium is completed as part of a group of tests referred to as a renal profile,
@@ -82,3 +91,6 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/sodium-tests-numerical-value/32bff605/
+  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274G3QAPB7QP12QMH4A6/
+  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMADFDX6MCPE2P9DHM2/
+  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273T25NQB2E84Y4X8HH2/

--- a/app/measures.yaml
+++ b/app/measures.yaml
@@ -1,4 +1,5 @@
 - name: Blood Pressure monitoring rate
+  shorthand: systolic_bp
   is_pathology: false
   explanation: >
     A commonly-used assessment used to identify patients with hypertension or to ensure optimal treatment for those with known hypertension.
@@ -10,11 +11,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: sustained drop
   codelist_url: https://www.opencodelists.org/codelist/opensafely/systolic-blood-pressure-qof/3572b5fb/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274J5CHBHZYTD38Q4X3Z/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGM5TB62ZPT4D3T7A56F/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273Y8PM2QYPWBDXWT433/
 
 - name: Cholesterol testing rate
+  shorthand: cholesterol
   is_pathology: true
   explanation: >
     A commonly-used blood test used as part of a routine cardiovascular disease 10 year risk assessment
@@ -27,11 +26,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/cholesterol-tests/0f1b2a4c/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12745NSRAF6CSV2Y5587V/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGN5YJM0VRCGQ979B68K/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273GGXHAVCHAWF9MZMPY/
 
 - name: Liver Function - Alanine Transferaminase (ALT) testing rate
+  shorthand: alt
   is_pathology: true
   explanation: >
     An ALT blood test is one of a group of liver function tests (LFTs) which are used to detect problems with the function of the liver.
@@ -44,11 +41,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/alanine-aminotransferase-alt-tests/2298df3e/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ127420DXX35BM0MMQNW8N/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGKSB1ANPP4X5V2FM3FR/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12739P6B7Z00QAJBTBKK3/
 
 - name: Red Blood Cell (RBC) count testing rate
+  shorthand: rbc
   is_pathology: true
   explanation: >
     RBC is completed as part of a group of tests referred to as a full blood count (FBC),
@@ -59,11 +54,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/red-blood-cell-rbc-tests/576a859e/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274E1QDEFYVGPFH13GBV/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGM2Q5PXN17JG59HZFRQ/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273RP68K1YM9TYRA2FBD/
 
 - name: Glycated Haemoglobin A1c (HbA1c) testing rate
+  shorthand: hba1c
   is_pathology: true
   explanation: >
     HbA1c is a long term indicator of diabetes control.
@@ -75,11 +68,9 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/glycated-haemoglobin-hba1c-tests/3e5b1269/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ12749JZ938746AV8XCPZ3/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMVQ62NGNM403MK32Z7/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273K1QJM5EQ7238X7P3S/
 
 - name: Renal Function - Sodium testing rate
+  shorthand: sodium
   is_pathology: true
   explanation: >
     Sodium is completed as part of a group of tests referred to as a renal profile,
@@ -91,6 +82,3 @@
     which will usually exclude tests requested while a person is in hospital and other settings like a private clinic.
   classification: recovery
   codelist_url: https://www.opencodelists.org/codelist/opensafely/sodium-tests-numerical-value/32bff605/
-  counts_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1274G3QAPB7QP12QMH4A6/
-  top_5_codes_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGWFEGMADFDX6MCPE2P9DHM2/
-  deciles_table_url: https://jobs.opensafely.org/service-restoration-observatory/sro-key-measures-dashboard/published/01GGZ1273T25NQB2E84Y4X8HH2/

--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -3,10 +3,7 @@ import streamlit
 
 
 def get_repository():
-    workspace = measures.OSJobsWorkspace(
-        "api/v2/workspaces/sro-key-measures-dashboard/snapshots/31"
-    )
-    return measures.OSJobsRepository(workspace.get_file_urls())
+    return measures.OSJobsRepository()
 
 
 def main():

--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -9,9 +9,7 @@ def get_repository():
 def main():
     repository = get_repository()
 
-    selected_measure_name = streamlit.selectbox(
-        "Select a measure:", repository.list(), index=0
-    )
+    selected_measure_name = streamlit.selectbox("Select a measure:", repository.list())
 
     measure = repository.get(selected_measure_name)
 


### PR DESCRIPTION
Reworked implementation of https://github.com/opensafely/open-pathology/commit/e563a29bd192e01f1b817808efa20442f55fa7cb.

This eliminates the human error in copy and pasting file URLs.
Unlike a codelist URL (which would contain the codelist name),
file URLs do not contain any hints about which measure the file is for,
so mistakes are very hard to spot.

The file URLs are now obtained programmatically from the Job Server API
and written to a separate file to `measures.yaml`.

The third commit is needed to trigger a redeployment - see #79.