### PR TITLE
Revert "Do not cache the repository"

### DIFF
--- a/app/sro_key_measures.py
+++ b/app/sro_key_measures.py
@@ -2,6 +2,7 @@ import measures
 import streamlit
 
 
+@streamlit.cache_resource
 def get_repository():
     return measures.OSJobsRepository()
 


### PR DESCRIPTION
We now have a means to reboot the app, so we can cache the repository.

This reverts commit 1c13a3a2f283d2f36b203bd57f017df7939eb163.