### PR TITLE
Display generic exception messages

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -27,6 +27,9 @@ services:
         value: "8080"
         scope: RUN_TIME
         type: GENERAL
+      - key: STREAMLIT_CLIENT_SHOW_ERROR_DETAILS
+        value: none
+        scope: RUN_TIME
     health_check:
       # See https://github.com/streamlit/streamlit/blob/1.50.0/lib/streamlit/web/server/server.py#L144-L146
       http_path: /_stcore/script-health-check


### PR DESCRIPTION
It's not possible to disable exception messages entirely, but this will display something like the following:

> This app has encountered an error. The original error message is redacted to prevent data leaks. Full error details have been recorded in the logs (if you're on Streamlit Cloud, click on 'Manage app' in the lower right of your app).