### PR TITLE
Add Plausible script

### DIFF
--- a/app/open_pathology.py
+++ b/app/open_pathology.py
@@ -14,6 +14,14 @@ def main():
         page_title="OpenPathology", page_icon=":material/prescriptions:", layout="wide"
     )
 
+    streamlit.html("""
+        <script async src="https://plausible.io/js/pa-_l1m42vU9r8g5GHYvdAqx.js"></script>
+        <script>
+            window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+            plausible.init()
+        </script>
+    """)
+
     streamlit.html(
         """
         <style>


### PR DESCRIPTION
We use Plausible to gather web analytics because they don't use cookies, don't collect personal data, and are based in the EU. Setting up Plausible within a Streamlit app is hit-and-miss, so we may need to revisit these changes.